### PR TITLE
Add library link test util

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "dotenv": "^8.2.0",
     "ethereum-waffle": "^3.2.1",
     "ethers": "^5.0.24",
+    "globby": "^11.0.2",
     "hardhat": "^2.0.6",
     "hardhat-deploy": "^0.7.0-beta.39",
     "hardhat-typechain": "^0.3.4",

--- a/utils/common/index.ts
+++ b/utils/common/index.ts
@@ -16,3 +16,6 @@ export {
 export { ether, gWei } from "./unitsUtils";
 export { Blockchain } from "./blockchainUtils";
 export { ProtocolUtils } from "./protocolUtils";
+export {
+  convertLibraryNameToLinkId
+} from "./libraryUtils";

--- a/utils/common/libraryUtils.ts
+++ b/utils/common/libraryUtils.ts
@@ -1,0 +1,54 @@
+import { utils } from "ethers";
+import { artifacts } from "hardhat";
+import { Artifact } from "hardhat/types";
+import path from "path";
+import globby from "globby";
+
+// If libraryName corresponds to more than one artifact (e.g there are
+// duplicate contract names in the project), `readArtifactSync`
+// will throw. In such cases it"s necessary to pass this method the fully qualified
+// contract name. ex: `contracts/mocks/LibraryMock.sol:LibraryMock`
+export function convertLibraryNameToLinkId(libraryName: string): string {
+  let artifact;
+  let fullyQualifiedName;
+
+  if (libraryName.includes(path.sep) && libraryName.includes(":")) {
+    fullyQualifiedName = libraryName;
+  } else {
+    artifact = getArtifact(libraryName);
+    fullyQualifiedName = `${artifact.sourceName}:${artifact.contractName}`;
+  }
+
+  const hashedName = utils.keccak256(utils.toUtf8Bytes(fullyQualifiedName));
+  return `__$${hashedName.slice(2).slice(0, 34)}$__`;
+}
+
+// Tries to resolve via hardhat artifacts helpers, then by searching for appropriately
+// named jsons in the root `external` folder
+function getArtifact(libraryName: string): Artifact {
+  try {
+    return artifacts.readArtifactSync(libraryName);
+  } catch (e) {
+    /* ignore */
+  }
+
+  const files = globby.sync("external", {
+    expandDirectories: { extensions: ["json"], },
+  });
+
+  const matches = files.filter(f => f.includes(`/${libraryName}.json`));
+
+  if (!matches.length) {
+    throw new Error(`Unable to find artifact for '${libraryName}' while linking.`);
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Unable to resolve '${libraryName}' while linking. ` +
+      `(More than one file name matches in 'external/')`
+    );
+  }
+
+  const pathToArtifact = path.join(process.cwd(), matches[0]);
+  return require(pathToArtifact);
+}

--- a/utils/deploys/deploySetV2.ts
+++ b/utils/deploys/deploySetV2.ts
@@ -1,6 +1,7 @@
-import { Signer, utils } from "ethers";
+import { Signer } from "ethers";
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 import { Address } from "../types";
+import { convertLibraryNameToLinkId } from "../common";
 import {
   Compound,
   CompoundLeverageModule,
@@ -130,18 +131,13 @@ export default class DeploySetV2 {
     cEther: Address,
     weth: Address,
   ): Promise<CompoundLeverageModule> {
-    // TO FIX: Pull library name from artifact's sourceName
-    const libraryName = "contracts/protocol/integration/lib/Compound.sol:Compound";
-    const hashedLibName = utils.keccak256(utils.toUtf8Bytes(libraryName));
-    const libKey = `__$${hashedLibName.slice(2).slice(0, 34)}$__`;
-
     const compoundLib = await this.deployCompoundLib();
-    const libraryAddress = compoundLib.address;
+    const linkId = convertLibraryNameToLinkId("Compound");
 
     return await new CompoundLeverageModule__factory(
       // @ts-ignore
       {
-        [libKey]: libraryAddress,
+        [linkId]: compoundLib.address,
       },
       // @ts-ignore
       this._deployerSigner

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,6 +3807,18 @@ fast-glob@^3.0.3:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.1.1:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4330,6 +4342,18 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
+globby@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
+  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 got@9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -4718,7 +4742,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==


### PR DESCRIPTION
Companion to [set-protocol-v2-private 34][1]. 

Adds a util to common which converts a short library name (like "Compound") into a link id that can be used as the key to an entry in the library links object passed to a typechain factory.

In this repo, contract artifacts from elsewhere are ported to the `external/` folder. This version of the helper first tries to resolve an artifact using Hardhat, then searches `external` for a `json` file matching the library short name.

(In the smart contract meeting we talked about using Typechain for this but given the way external artifacts are managed here this seemed like the simplest / clearest approach. Idk - open to suggestions).

[EDIT - thought about this more ... there are a few things being done in these repos to "fix" hardhat-typechain / make it suitable for conditions here. Might make sense long-term to fork it and centralize those things in one place.)

[1]: https://github.com/SetProtocol/set-protocol-v2-private/pull/34