### PR TITLE
Explicitly configure localhost network gas settings

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -37,6 +37,8 @@ const config: HardhatUserConfig = {
     },
     localhost: {
       url: "http://127.0.0.1:8545",
+      gas: 9500000,
+      blockGasLimit: 9500000,
     },
     kovan: {
       url: "https://kovan.infura.io/v3/" + process.env.INFURA_TOKEN,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -37,8 +37,8 @@ const config: HardhatUserConfig = {
     },
     localhost: {
       url: "http://127.0.0.1:8545",
-      gas: 9500000,
-      blockGasLimit: 9500000,
+      gas: 12000000,
+      blockGasLimit: 12000000,
     },
     kovan: {
       url: "https://kovan.infura.io/v3/" + process.env.INFURA_TOKEN,


### PR DESCRIPTION
Patches a problem with the way abi gas injection works when using `localhost` locally in a development flow. The gas and blockGasLimit need to be specified for the network in order for this to work.

At the moment, they default to `auto` instead of a number.

`9,500,000` is the default block limit for the Hardhat version we currently use (2.0.6)