### PR TITLE
Supply cap / allowed contract caller issuance hook

### DIFF
--- a/contracts/hooks/SupplyCapAllowedCallerIssuanceHook.sol
+++ b/contracts/hooks/SupplyCapAllowedCallerIssuanceHook.sol
@@ -1,0 +1,157 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
+
+import { IManagerIssuanceHook } from "../interfaces/IManagerIssuanceHook.sol";
+import { ISetToken } from "../interfaces/ISetToken.sol";
+
+
+/**
+ * @title SupplyCapAllowedCallerIssuanceHook
+ * @author Set Protocol
+ *
+ * Issuance hook that checks new issuances won't push SetToken totalSupply over supply cap and checks if caller is allowed
+ */
+contract SupplyCapAllowedCallerIssuanceHook is Ownable, IManagerIssuanceHook {
+    using SafeMath for uint256;
+    using AddressArrayUtils for address[];
+
+    /* ============ Events ============ */
+
+    event SupplyCapUpdated(uint256 _newCap);
+    event CallerStatusUpdated(address indexed _caller, bool _status);
+    event AnyoneCallableUpdated(bool indexed _status);
+    
+    /* ============ State Variables ============ */
+
+    // Cap on totalSupply of Sets
+    uint256 public supplyCap;
+
+    // Boolean indicating if anyone can call function
+    bool public anyoneCallable;
+
+    // Mapping of addresses allowed to call function
+    mapping(address => bool) public callAllowList;
+
+    /* ============ Constructor ============ */
+
+    /**
+     * Constructor, overwrites owner and original supply cap.
+     *
+     * @param _initialOwner      Owner address, overwrites Ownable logic which sets to deployer as default
+     * @param _supplyCap         Supply cap for Set (in wei of Set)
+     */
+    constructor(
+        address _initialOwner,
+        uint256 _supplyCap
+    )
+        public
+    {
+        supplyCap = _supplyCap;
+
+        // Overwrite _owner param of Ownable contract
+        transferOwnership(_initialOwner);
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * Adheres to IManagerIssuanceHook interface, and checks to make sure the current issue call won't push total supply over cap.
+     */
+    function invokePreIssueHook(
+        ISetToken _setToken,
+        uint256 _issueQuantity,
+        address _sender,
+        address /*_to*/
+    )
+        external
+        override
+    {
+        uint256 totalSupply = _setToken.totalSupply();
+        require(totalSupply.add(_issueQuantity) <= supplyCap, "Supply cap exceeded");
+
+        _validateAllowedCaller(_sender);
+    }
+
+    /**
+     * Adheres to IManagerIssuanceHook interface
+     */
+    function invokePreRedeemHook(
+        ISetToken /* _setToken */,
+        uint256 /* _redeemQuantity */,
+        address _sender,
+        address /* _to */
+    )
+        external
+        override
+    {
+        _validateAllowedCaller(_sender);
+    }
+
+    /**
+     * ONLY OWNER: Updates supply cap
+     */
+    function updateSupplyCap(uint256 _newCap) external onlyOwner {
+        supplyCap = _newCap;
+        SupplyCapUpdated(_newCap);
+    }
+
+    /**
+     * ONLY OWNER: Toggle ability for passed addresses to call only allowed caller functions
+     *
+     * @param _callers           Array of caller addresses to toggle status
+     * @param _statuses          Array of statuses for each caller
+     */
+    function updateCallerStatus(address[] calldata _callers, bool[] calldata _statuses) external onlyOwner {
+        require(_callers.length == _statuses.length, "Array length mismatch");
+        require(_callers.length > 0, "Array length must be > 0");
+        require(!_callers.hasDuplicate(), "Cannot duplicate callers");
+
+        for (uint256 i = 0; i < _callers.length; i++) {
+            address caller = _callers[i];
+            bool status = _statuses[i];
+            callAllowList[caller] = status;
+            emit CallerStatusUpdated(caller, status);
+        }
+    }
+
+    /**
+     * ONLY OWNER: Toggle whether anyone can call function, bypassing the callAllowlist 
+     *
+     * @param _status           Boolean indicating whether to allow anyone call
+     */
+    function updateAnyoneCallable(bool _status) external onlyOwner {
+        anyoneCallable = _status;
+        emit AnyoneCallableUpdated(_status);
+    }
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * Validate if passed address is allowed to call function. If anyoneCallable set to true anyone can call otherwise needs to be approved or an EOA.
+     */
+    function _validateAllowedCaller(address _caller) internal view {
+        bool isEOA = msg.sender == tx.origin;
+
+        require(anyoneCallable || isEOA || callAllowList[_caller], "Address not permitted to call");
+    }
+}

--- a/contracts/hooks/SupplyCapAllowedCallerIssuanceHook.sol
+++ b/contracts/hooks/SupplyCapAllowedCallerIssuanceHook.sol
@@ -122,9 +122,7 @@ contract SupplyCapAllowedCallerIssuanceHook is Ownable, IManagerIssuanceHook {
      * @param _statuses          Array of statuses for each caller
      */
     function updateCallerStatus(address[] calldata _callers, bool[] calldata _statuses) external onlyOwner {
-        require(_callers.length == _statuses.length, "Array length mismatch");
-        require(_callers.length > 0, "Array length must be > 0");
-        require(!_callers.hasDuplicate(), "Cannot duplicate callers");
+        _callers.validatePairsWithArray(_statuses);
 
         for (uint256 i = 0; i < _callers.length; i++) {
             address caller = _callers[i];

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -58,10 +58,10 @@ const config: HardhatUserConfig = {
 
 function getHardhatPrivateKeys() {
   return privateKeys.map(key => {
-    const HUNDRED_THOUSAND_ETH = "100000000000000000000000";
+    const TEN_MILLION_ETH = "10000000000000000000000000";
     return {
       privateKey: key,
-      balance: HUNDRED_THOUSAND_ETH,
+      balance: TEN_MILLION_ETH,
     };
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/index-coop-contracts",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/test/hooks/supplyCapAllowedCallerIssuanceHook.spec.ts
+++ b/test/hooks/supplyCapAllowedCallerIssuanceHook.spec.ts
@@ -1,0 +1,310 @@
+import "module-alias/register";
+
+import { Address, Account } from "@utils/types";
+import { ZERO } from "@utils/constants";
+import { SupplyCapAllowedCallerIssuanceHook } from "@utils/contracts/index";
+import { ContractCallerMock, SetToken } from "@utils/contracts/setV2";
+import DeployHelper from "@utils/deploys";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  ether,
+  getAccounts,
+  getSetFixture,
+  getWaffleExpect,
+  getRandomAccount,
+} from "@utils/index";
+import { SetFixture } from "@utils/fixtures";
+import { BigNumber, ContractTransaction } from "ethers";
+
+const expect = getWaffleExpect();
+
+describe("SupplyCapAllowedCallerIssuanceHook", () => {
+  let owner: Account;
+  let hookOwner: Account;
+  let otherAccount: Account;
+  let setV2Setup: SetFixture;
+
+  let deployer: DeployHelper;
+  let setToken: SetToken;
+
+  let issuanceHook: SupplyCapAllowedCallerIssuanceHook;
+
+  before(async () => {
+    [
+      owner,
+      hookOwner,
+      otherAccount,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSetFixture(owner.address);
+    await setV2Setup.initialize();
+
+    setToken = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address],
+      [ether(1)],
+      [setV2Setup.debtIssuanceModule.address]
+    );
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("#constructor", async () => {
+    let subjectOwner: Address;
+    let subjectSupplyCap: BigNumber;
+
+    beforeEach(async () => {
+      subjectOwner = hookOwner.address;
+      subjectSupplyCap = ether(10);
+    });
+
+    async function subject(): Promise<SupplyCapAllowedCallerIssuanceHook> {
+      return await deployer.hooks.deploySupplyCapAllowedCallerIssuanceHook(subjectOwner, subjectSupplyCap);
+    }
+
+    it("should set the correct SetToken address", async () => {
+      const hook = await subject();
+
+      const actualSupplyCap = await hook.supplyCap();
+      expect(actualSupplyCap).to.eq(subjectSupplyCap);
+    });
+
+    it("should set the correct owner address", async () => {
+      const hook = await subject();
+
+      const actualOwner = await hook.owner();
+      expect(actualOwner).to.eq(subjectOwner);
+    });
+  });
+
+  describe("#invokePreIssueHook", async () => {
+    let subjectSetToken: Address;
+    let subjectQuantity: BigNumber;
+    let subjectTo: Address;
+
+    beforeEach(async () => {
+      issuanceHook = await deployer.hooks.deploySupplyCapAllowedCallerIssuanceHook(owner.address, ether(10));
+
+      await setV2Setup.debtIssuanceModule.initialize(
+        setToken.address,
+        ether(.1),
+        ether(.01),
+        ether(.01),
+        owner.address,
+        issuanceHook.address
+      );
+
+      await setV2Setup.dai.approve(setV2Setup.debtIssuanceModule.address, ether(100));
+
+      subjectSetToken = setToken.address;
+      subjectQuantity = ether(5);
+      subjectTo = owner.address;
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return await setV2Setup.debtIssuanceModule.issue(
+        subjectSetToken,
+        subjectQuantity,
+        subjectTo
+      );
+    }
+
+    it("should not revert", async () => {
+      await expect(subject()).to.not.be.reverted;
+    });
+
+    describe("when total issuance quantity forces supply over the limit", async () => {
+      beforeEach(async () => {
+        subjectQuantity = ether(11);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Supply cap exceeded");
+      });
+    });
+
+    describe("when the sender is not EOA and on allowlist", async () => {
+      let subjectTarget: Address;
+      let subjectCallData: string;
+      let subjectValue: BigNumber;
+
+      let contractCaller: ContractCallerMock;
+
+      beforeEach(async () => {
+        contractCaller = await deployer.setV2.deployContractCallerMock();
+        await issuanceHook.updateCallerStatus([contractCaller.address], [true]);
+
+        await setV2Setup.dai.transfer(contractCaller.address, ether(50));
+        // Approve token from contract caller to issuance module
+        const approveData = setV2Setup.dai.interface.encodeFunctionData("approve", [
+          setV2Setup.debtIssuanceModule.address,
+          ether(100),
+        ]);
+        await contractCaller.invoke(setV2Setup.dai.address, ZERO, approveData);
+
+        subjectSetToken = setToken.address;
+        subjectQuantity = ether(5);
+        subjectTo = owner.address;
+
+        subjectTarget = setV2Setup.debtIssuanceModule.address;
+        subjectCallData = setV2Setup.debtIssuanceModule.interface.encodeFunctionData("issue", [
+          subjectSetToken,
+          subjectQuantity,
+          subjectTo,
+        ]);
+
+        subjectValue = ZERO;
+      });
+
+      async function subjectContractCaller(): Promise<any> {
+        return await contractCaller.invoke(
+          subjectTarget,
+          subjectValue,
+          subjectCallData
+        );
+      }
+
+      it("should not revert", async () => {
+        await expect(subjectContractCaller()).to.not.be.reverted;
+      });
+
+      describe("when the caller is not on allowlist", async () => {
+        beforeEach(async () => {
+          await issuanceHook.updateCallerStatus([contractCaller.address], [false]);
+        });
+
+        it("should revert", async () => {
+          await expect(subjectContractCaller()).to.be.revertedWith("Contract not permitted to call");
+        });
+
+        describe("when anyoneCallable is flipped to true", async () => {
+          beforeEach(async () => {
+            await issuanceHook.updateAnyoneCallable(true);
+          });
+
+          it("should succeed without revert", async () => {
+            await subjectContractCaller();
+          });
+        });
+      });
+    });
+  });
+
+  describe("#updateSupplyCap", async () => {
+    let subjectNewCap: BigNumber;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      issuanceHook = await deployer.hooks.deploySupplyCapAllowedCallerIssuanceHook(owner.address, ether(10));
+
+      subjectNewCap = ether(20);
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return await issuanceHook.connect(subjectCaller.wallet).updateSupplyCap(subjectNewCap);
+    }
+
+    it("should update supply cap", async () => {
+      await subject();
+
+      const actualCap = await issuanceHook.supplyCap();
+
+      expect(actualCap).to.eq(subjectNewCap);
+    });
+
+    it("should emit the correct SupplyCapUpdated event", async () => {
+      await expect(subject()).to.emit(issuanceHook, "SupplyCapUpdated").withArgs(subjectNewCap);
+    });
+
+    describe("when caller is not owner", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+  });
+
+  describe("#updateCallerStatus", async () => {
+    let subjectFunctionCallers: Address[];
+    let subjectStatuses: boolean[];
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      issuanceHook = await deployer.hooks.deploySupplyCapAllowedCallerIssuanceHook(owner.address, ether(10));
+
+      subjectFunctionCallers = [otherAccount.address];
+      subjectStatuses = [true];
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return issuanceHook.connect(subjectCaller.wallet).updateCallerStatus(subjectFunctionCallers, subjectStatuses);
+    }
+
+    it("should update the callAllowList", async () => {
+      await subject();
+      const callerStatus = await issuanceHook.callAllowList(subjectFunctionCallers[0]);
+      expect(callerStatus).to.be.true;
+    });
+
+    it("should emit CallerStatusUpdated event", async () => {
+      await expect(subject()).to.emit(issuanceHook, "CallerStatusUpdated").withArgs(
+        subjectFunctionCallers[0],
+        subjectStatuses[0]
+      );
+    });
+
+    describe("when the sender is not owner", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+  });
+
+  describe("#updateAnyoneCallable", async () => {
+    let subjectStatus: boolean;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      issuanceHook = await deployer.hooks.deploySupplyCapAllowedCallerIssuanceHook(owner.address, ether(10));
+
+      subjectStatus = true;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return issuanceHook.connect(subjectCaller.wallet).updateAnyoneCallable(subjectStatus);
+    }
+
+    it("should update the anyoneCallable boolean", async () => {
+      await subject();
+      const callerStatus = await issuanceHook.anyoneCallable();
+      expect(callerStatus).to.be.true;
+    });
+
+    it("should emit AnyoneCallableUpdated event", async () => {
+      await expect(subject()).to.emit(issuanceHook, "AnyoneCallableUpdated").withArgs(
+        subjectStatus
+      );
+    });
+
+    describe("when the sender is not owner", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+  });
+});

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -6,6 +6,7 @@ export { FeeSplitAdapter } from "../../typechain/FeeSplitAdapter";
 export { FlexibleLeverageStrategyAdapter } from "../../typechain/FlexibleLeverageStrategyAdapter";
 export { FLIRebalanceViewer } from "../../typechain/FLIRebalanceViewer";
 export { SupplyCapIssuanceHook } from "../../typechain/SupplyCapIssuanceHook";
+export { SupplyCapAllowedCallerIssuanceHook } from "../../typechain/SupplyCapAllowedCallerIssuanceHook";
 export { IndexToken } from "../../typechain/IndexToken";
 export { MerkleDistributor } from "../../typechain/MerkleDistributor";
 export { MutualUpgradeMock } from "../../typechain/MutualUpgradeMock";

--- a/utils/deploys/deployHooks.ts
+++ b/utils/deploys/deployHooks.ts
@@ -1,8 +1,10 @@
 import { Signer, BigNumber } from "ethers";
 import { Address } from "../types";
 import { SupplyCapIssuanceHook } from "../contracts/index";
+import { SupplyCapAllowedCallerIssuanceHook } from "../contracts/index";
 
 import { SupplyCapIssuanceHook__factory } from "../../typechain/factories/SupplyCapIssuanceHook__factory";
+import { SupplyCapAllowedCallerIssuanceHook__factory } from "../../typechain/factories/SupplyCapAllowedCallerIssuanceHook__factory";
 
 export default class DeployHooks {
   private _deployerSigner: Signer;
@@ -16,5 +18,12 @@ export default class DeployHooks {
     supplyCap: BigNumber
   ): Promise<SupplyCapIssuanceHook> {
     return await new SupplyCapIssuanceHook__factory(this._deployerSigner).deploy(initialOwner, supplyCap);
+  }
+
+  public async deploySupplyCapAllowedCallerIssuanceHook(
+    initialOwner: Address,
+    supplyCap: BigNumber
+  ): Promise<SupplyCapAllowedCallerIssuanceHook> {
+    return await new SupplyCapAllowedCallerIssuanceHook__factory(this._deployerSigner).deploy(initialOwner, supplyCap);
   }
 }


### PR DESCRIPTION
Note: Set Protocol Debt Issuance Module does not have a pre redeem hook, and so the allowlist can only be applied on issuance