### PR TITLE
Port AddressArrayUtils #_validatePairsWithArray helpers

### DIFF
--- a/contracts/lib/AddressArrayUtils.sol
+++ b/contracts/lib/AddressArrayUtils.sol
@@ -23,6 +23,9 @@ pragma solidity 0.6.10;
  * @author Set Protocol
  *
  * Utility functions to handle Address Arrays
+ *
+ * CHANGELOG:
+ * - 4/27/21: Added validatePairsWithArray methods
  */
 library AddressArrayUtils {
 
@@ -74,7 +77,7 @@ library AddressArrayUtils {
 
     /**
      * @param A The input array to search
-     * @param a The address to remove     
+     * @param a The address to remove
      * @return Returns the array with the object removed.
      */
     function remove(address[] memory A, address a)
@@ -148,5 +151,75 @@ library AddressArrayUtils {
             newAddresses[aLength + j] = B[j];
         }
         return newAddresses;
+    }
+
+    /**
+     * Validate that address and uint array lengths match. Validate address array is not empty
+     * and contains no duplicate elements.
+     *
+     * @param A         Array of addresses
+     * @param B         Array of uint
+     */
+    function validatePairsWithArray(address[] memory A, uint[] memory B) internal pure {
+        require(A.length == B.length, "Array length mismatch");
+        _validateLengthAndUniqueness(A);
+    }
+
+    /**
+     * Validate that address and bool array lengths match. Validate address array is not empty
+     * and contains no duplicate elements.
+     *
+     * @param A         Array of addresses
+     * @param B         Array of bool
+     */
+    function validatePairsWithArray(address[] memory A, bool[] memory B) internal pure {
+        require(A.length == B.length, "Array length mismatch");
+        _validateLengthAndUniqueness(A);
+    }
+
+    /**
+     * Validate that address and string array lengths match. Validate address array is not empty
+     * and contains no duplicate elements.
+     *
+     * @param A         Array of addresses
+     * @param B         Array of strings
+     */
+    function validatePairsWithArray(address[] memory A, string[] memory B) internal pure {
+        require(A.length == B.length, "Array length mismatch");
+        _validateLengthAndUniqueness(A);
+    }
+
+    /**
+     * Validate that address array lengths match, and calling address array are not empty
+     * and contain no duplicate elements.
+     *
+     * @param A         Array of addresses
+     * @param B         Array of addresses
+     */
+    function validatePairsWithArray(address[] memory A, address[] memory B) internal pure {
+        require(A.length == B.length, "Array length mismatch");
+        _validateLengthAndUniqueness(A);
+    }
+
+    /**
+     * Validate that address and bytes array lengths match. Validate address array is not empty
+     * and contains no duplicate elements.
+     *
+     * @param A         Array of addresses
+     * @param B         Array of bytes
+     */
+    function validatePairsWithArray(address[] memory A, bytes[] memory B) internal pure {
+        require(A.length == B.length, "Array length mismatch");
+        _validateLengthAndUniqueness(A);
+    }
+
+    /**
+     * Validate address array is not empty and contains no duplicate elements.
+     *
+     * @param A          Array of addresses
+     */
+    function _validateLengthAndUniqueness(address[] memory A) internal pure {
+        require(A.length > 0, "Array length must be > 0");
+        require(!hasDuplicate(A), "Cannot duplicate addresses");
     }
 }


### PR DESCRIPTION
PR adds helpers to do common validation checks between an address array and comparison array of another type.

Handles bool, string, uint256, bytes[], address comparisons.

Checks that:
+ the caller and comparison arrays are the same length
+ the calling array is not zero length
+ calling array has no duplicate components

These were added (with tests) in [set-protocol-v2 75][1]

[1]: https://github.com/SetProtocol/set-protocol-v2/pull/75