### PR TITLE
Update package for public npm (make ethers a non-dev dep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,14 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "build": "yarn compile && yarn patch-hardhat-typechain && yarn typechain && yarn fix-typechain && yarn transpile-dist",
+    "build": "yarn compile && yarn build:typechain",
+    "build:npm": "yarn compile:npm && yarn build:typechain",
+    "build:typechain": "yarn patch-hardhat-typechain && yarn typechain && yarn fix-typechain && yarn transpile-dist",
     "chain": "npx hardhat node --no-deploy",
-    "clean": "rm -f coverage.json; rm -rf .coverage_cache; rm -rf .coverage_contracts; rm -rf cache; rm -rf coverage; rm -rf typechain; rm -rf artifacts",
+    "clean": "rm -rf coverage.json .coverage_cache .coverage_contracts cache coverage typechain artifacts dist",
     "clean-dev-deployment": "rm -rf deployments/50-development.json",
     "compile": "npx hardhat compile",
+    "compile:npm": "SKIP_ABI_GAS_MODS=true npx hardhat compile",
     "coverage": "yarn clean && yarn build && yarn cov:command",
     "coverage:fork": "yarn clean && yarn build && FORK=true yarn cov:command",
     "cov:command": "COVERAGE=true node --max-old-space-size=4096 ./node_modules/.bin/hardhat coverage",
@@ -31,7 +34,7 @@
     "patch-hardhat-typechain": "node scripts/patch-hardhat-typechain.js",
     "precommit": "lint-staged",
     "prepare": "yarn build",
-    "prepack": "if [[ \"$(basename \"$PWD\")\" == \"index-coop-contracts\" ]]; then echo \"CANNOT PUBLISH FROM THIS REPO\"; exit 1; fi;",
+    "prepublishOnly": "yarn clean && yarn build:npm",
     "rename-extensions": "for f in typechain/*.d.ts; do mv -- \"$f\" \"${f%.d.ts}.ts\"; done",
     "test": "npx hardhat test --network localhost",
     "test:fork": "FORK=true npx hardhat test",
@@ -89,6 +92,11 @@
     "module-alias": "^2.2.2",
     "replace-in-file": "^6.1.0",
     "typechain": "^4.0.1"
+  },
+  "peerDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "ethereum-waffle": "^3.2.1",
+    "hardhat": "^2.2.1"
   },
   "_moduleAliases": {
     "@utils": "utils",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
   "license": "MIT",
   "homepage": "https://github.com/SetProtocol",
   "devDependencies": {
-    "@ethersproject/abstract-signer": "^5.0.9",
-    "@ethersproject/bignumber": "^5.0.12",
-    "@ethersproject/providers": "^5.0.17",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.1.0",
@@ -64,7 +61,6 @@
     "coveralls": "^3.0.1",
     "dotenv": "^8.2.0",
     "ethereum-waffle": "^3.2.1",
-    "ethers": "^5.0.24",
     "globby": "^11.0.2",
     "hardhat": "^2.0.6",
     "hardhat-deploy": "^0.7.0-beta.39",
@@ -82,9 +78,13 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "@ethersproject/abstract-signer": "5.0.9",
+    "@ethersproject/bignumber": "5.0.12",
+    "@ethersproject/providers": "5.0.17",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "ethereumjs-util": "^7.0.5",
+    "ethers": "5.0.24",
     "fs-extra": "^5.0.0",
     "module-alias": "^2.2.2",
     "replace-in-file": "^6.1.0",

--- a/tasks/subtasks.ts
+++ b/tasks/subtasks.ts
@@ -12,7 +12,13 @@ import { addGasToAbiMethods, setupNativeSolc } from "../utils/tasks";
 subtask(TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT)
   .setAction(async (_, { network }, runSuper) => {
     const artifact = await runSuper();
-    artifact.abi = addGasToAbiMethods(network.config, artifact.abi);
+
+    // These changes should be skipped when publishing to npm.
+    // They override ethers' gas estimation
+    if (!process.env.SKIP_ABI_GAS_MODS){
+      artifact.abi = addGasToAbiMethods(network.config, artifact.abi);
+    }
+
     return artifact;
   }
 );

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,8 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "test/**/*.ts",
-    "tasks/**/*.ts",
-    "hardhat.config.ts"
+    "test/**/*.ts"
   ]
 }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "test/**/*.ts"
+    "test/**/*.ts",
+    "tasks/**/*.ts",
+    "hardhat.config.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,7 +132,7 @@
     "@ethersproject/transactions" "^5.0.5"
     "@ethersproject/web" "^5.0.6"
 
-"@ethersproject/abstract-signer@5.0.9", "@ethersproject/abstract-signer@^5.0.2", "@ethersproject/abstract-signer@^5.0.4", "@ethersproject/abstract-signer@^5.0.6", "@ethersproject/abstract-signer@^5.0.9":
+"@ethersproject/abstract-signer@5.0.9", "@ethersproject/abstract-signer@^5.0.2", "@ethersproject/abstract-signer@^5.0.4", "@ethersproject/abstract-signer@^5.0.6":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.0.9.tgz#238ddc06031aeb9dfceee2add965292d7dd1acbf"
   integrity sha512-CM5UNmXQaA03MyYARFDDRjHWBxujO41tVle7glf5kHcQsDDULgqSVpkliLJMtPzZjOKFeCVZBHybTZDEZg5zzg==
@@ -169,7 +169,7 @@
     "@ethersproject/bytes" "^5.0.4"
     "@ethersproject/properties" "^5.0.3"
 
-"@ethersproject/bignumber@5.0.12", "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.12", "@ethersproject/bignumber@^5.0.5", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.0.8":
+"@ethersproject/bignumber@5.0.12", "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.0.10", "@ethersproject/bignumber@^5.0.5", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.0.8":
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.12.tgz#fe4a78667d7cb01790f75131147e82d6ea7e7cba"
   integrity sha512-mbFZjwthx6vFlHG9owXP/C5QkNvsA+xHpDCkPPPdG2n1dS9AmZAL5DI0InNLid60rQWL3MXpEl19tFmtL7Q9jw==
@@ -293,7 +293,7 @@
   dependencies:
     "@ethersproject/logger" "^5.0.5"
 
-"@ethersproject/providers@5.0.17", "@ethersproject/providers@^5.0.17", "@ethersproject/providers@^5.0.5":
+"@ethersproject/providers@5.0.17", "@ethersproject/providers@^5.0.5":
   version "5.0.17"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.0.17.tgz#f380e7831149e24e7a1c6c9b5fb1d6dfc729d024"
   integrity sha512-bJnvs5X7ttU5x2ekGJYG7R3Z+spZawLFfR0IDsbaMDLiCwZOyrgk+VTBU7amSFLT0WUhWFv8WwSUB+AryCQG1Q==
@@ -3541,22 +3541,7 @@ ethereumjs-wallet@0.6.5:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^4.0.32:
-  version "4.0.48"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
-  integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
-  dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.3"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
-ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.24:
+ethers@5.0.24, ethers@^5.0.0, ethers@^5.0.1:
   version "5.0.24"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.24.tgz#fbb8e4d35070d134f2eb846c07500b8c0eaef6d3"
   integrity sha512-77CEtVC88fJGEhxGXRvQqAEH6e2A+ZFiv2FBT6ikXndlty5sw6vMatAhg1v+w3CaaGZOf1CP81jl4Mc8Zrj08A==
@@ -3591,6 +3576,21 @@ ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.24:
     "@ethersproject/wallet" "5.0.9"
     "@ethersproject/web" "5.0.11"
     "@ethersproject/wordlists" "5.0.7"
+
+ethers@^4.0.32:
+  version "4.0.48"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
+  integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.5.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"


### PR DESCRIPTION
(Companion to [set-protocol 92][4])

This makes sure `ethers` packages are included in the published package (they're required for dist/typechain and some utils) by moving them to regular dependencies.

Have pinned these deps since the exact versions we have yarn.locked [are required for everything to work together correctly][1]. A user who installed with floating versions would get whatever latest is within the range and run into tsc errors.

~~Also removed `tasks` and the hardhat config from the dist since they're for local development.~~

[1]: https://app.circleci.com/pipelines/github/SetProtocol/set-protocol-v2/492/workflows/3d4204b1-8d89-45cd-9040-a85cb4442998/jobs/1684

[4]: https://github.com/SetProtocol/set-protocol-v2/pull/92