### PR TITLE
Add ExchangeIssuanceV2 contract

### DIFF
--- a/contracts/exchangeIssuance/ExchangeIssuanceV2.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuanceV2.sol
@@ -1,0 +1,808 @@
+/*
+    Copyright 2021 Index Cooperative
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
+
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IUniswapV2Factory } from "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
+import { IUniswapV2Router02 } from "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
+import { Math } from "@openzeppelin/contracts/math/Math.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import { IBasicIssuanceModule } from "../interfaces/IBasicIssuanceModule.sol";
+import { IController } from "../interfaces/IController.sol";
+import { ISetToken } from "../interfaces/ISetToken.sol";
+import { IWETH } from "../interfaces/IWETH.sol";
+import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
+import { UniSushiV2Library } from "../../external/contracts/UniSushiV2Library.sol";
+
+/**
+ * @title ExchangeIssuance
+ * @author Index Coop
+ *
+ * Contract for issuing and redeeming any SetToken using ETH or an ERC20 as the paying/receiving currency.
+ * All swaps are done using the best price found on Uniswap or Sushiswap.
+ *
+ */
+contract ExchangeIssuanceV2 is ReentrancyGuard {
+
+    using Address for address payable;
+    using SafeMath for uint256;
+    using PreciseUnitMath for uint256;
+    using SafeERC20 for IERC20;
+    using SafeERC20 for ISetToken;
+
+    /* ============ Enums ============ */
+
+    enum Exchange { Uniswap, Sushiswap, None }
+
+    /* ============ Constants ============= */
+
+    uint256 constant private MAX_UINT96 = 2**96 - 1;
+    address constant public ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /* ============ State Variables ============ */
+
+    address public WETH;
+    IUniswapV2Router02 public uniRouter;
+    IUniswapV2Router02 public sushiRouter;
+
+    address public immutable uniFactory;
+    address public immutable sushiFactory;
+
+    IController public immutable setController;
+    IBasicIssuanceModule public immutable basicIssuanceModule;
+
+    /* ============ Events ============ */
+
+    event ExchangeIssue(
+        address indexed _recipient,     // The recipient address of the issued SetTokens
+        ISetToken indexed _setToken,    // The issued SetToken
+        IERC20 indexed _inputToken,     // The address of the input asset(ERC20/ETH) used to issue the SetTokens
+        uint256 _amountInputToken,      // The amount of input tokens used for issuance
+        uint256 _amountSetIssued        // The amount of SetTokens received by the recipient
+    );
+
+    event ExchangeRedeem(
+        address indexed _recipient,     // The recipient address which redeemed the SetTokens
+        ISetToken indexed _setToken,    // The redeemed SetToken
+        IERC20 indexed _outputToken,    // The address of output asset(ERC20/ETH) received by the recipient
+        uint256 _amountSetRedeemed,     // The amount of SetTokens redeemed for output tokens
+        uint256 _amountOutputToken      // The amount of output tokens received by the recipient
+    );
+
+    event Refund(
+        address indexed _recipient,     // The recipient address which redeemed the SetTokens
+        uint256 _refundAmount           // The amount of ETH redunded to the recipient
+    );
+
+    /* ============ Modifiers ============ */
+
+    modifier isSetToken(ISetToken _setToken) {
+         require(setController.isSet(address(_setToken)), "ExchangeIssuance: INVALID SET");
+         _;
+    }
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        address _weth,
+        address _uniFactory,
+        IUniswapV2Router02 _uniRouter,
+        address _sushiFactory,
+        IUniswapV2Router02 _sushiRouter,
+        IController _setController,
+        IBasicIssuanceModule _basicIssuanceModule
+    )
+        public
+    {
+        uniFactory = _uniFactory;
+        uniRouter = _uniRouter;
+
+        sushiFactory = _sushiFactory;
+        sushiRouter = _sushiRouter;
+
+        setController = _setController;
+        basicIssuanceModule = _basicIssuanceModule;
+
+        WETH = _weth;
+        IERC20(WETH).safeApprove(address(uniRouter), PreciseUnitMath.maxUint256());
+        IERC20(WETH).safeApprove(address(sushiRouter), PreciseUnitMath.maxUint256());
+    }
+
+    /* ============ Public Functions ============ */
+
+    /**
+     * Runs all the necessary approval functions required for a given ERC20 token.
+     * This function can be called when a new token is added to a SetToken during a
+     * rebalance.
+     *
+     * @param _token    Address of the token which needs approval
+     */
+    function approveToken(IERC20 _token) public {
+        _safeApprove(_token, address(uniRouter), MAX_UINT96);
+        _safeApprove(_token, address(sushiRouter), MAX_UINT96);
+        _safeApprove(_token, address(basicIssuanceModule), MAX_UINT96);
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * Runs all the necessary approval functions required for a list of ERC20 tokens.
+     *
+     * @param _tokens    Addresses of the tokens which need approval
+     */
+    function approveTokens(IERC20[] calldata _tokens) external {
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            approveToken(_tokens[i]);
+        }
+    }
+
+    /**
+     * Runs all the necessary approval functions required before issuing
+     * or redeeming a SetToken. This function need to be called only once before the first time
+     * this smart contract is used on any particular SetToken.
+     *
+     * @param _setToken    Address of the SetToken being initialized
+     */
+    function approveSetToken(ISetToken _setToken) isSetToken(_setToken) external {
+        address[] memory components = _setToken.getComponents();
+        for (uint256 i = 0; i < components.length; i++) {
+            // Check that the component does not have external positions
+            require(
+                _setToken.getExternalPositionModules(components[i]).length == 0,
+                "ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
+            );
+            approveToken(IERC20(components[i]));
+        }
+    }
+
+    /**
+     * Issues SetTokens for an exact amount of input ERC20 tokens.
+     * The ERC20 token must be approved by the sender to this contract.
+     *
+     * @param _setToken         Address of the SetToken being issued
+     * @param _inputToken       Address of input token
+     * @param _amountInput      Amount of the input token / ether to spend
+     * @param _minSetReceive    Minimum amount of SetTokens to receive. Prevents unnecessary slippage.
+     *
+     * @return setTokenAmount   Amount of SetTokens issued to the caller
+     */
+    function issueSetForExactToken(
+        ISetToken _setToken,
+        IERC20 _inputToken,
+        uint256 _amountInput,
+        uint256 _minSetReceive
+    )
+        isSetToken(_setToken)
+        external
+        nonReentrant
+        returns (uint256)
+    {
+        require(_amountInput > 0, "ExchangeIssuance: INVALID INPUTS");
+
+        _inputToken.safeTransferFrom(msg.sender, address(this), _amountInput);
+
+        uint256 amountEth = address(_inputToken) == WETH
+            ? _amountInput
+            : _swapTokenForWETH(_inputToken, _amountInput);
+
+        uint256 setTokenAmount = _issueSetForExactWETH(_setToken, _minSetReceive, amountEth);
+
+        emit ExchangeIssue(msg.sender, _setToken, _inputToken, _amountInput, setTokenAmount);
+        return setTokenAmount;
+    }
+
+    /**
+    * Issues an exact amount of SetTokens for given amount of input ERC20 tokens.
+    * The excess amount of tokens is returned in an equivalent amount of ether.
+    *
+    * @param _setToken              Address of the SetToken to be issued
+    * @param _inputToken            Address of the input token
+    * @param _amountSetToken        Amount of SetTokens to issue
+    * @param _maxAmountInputToken   Maximum amount of input tokens to be used to issue SetTokens. The unused
+    *                               input tokens are returned as ether.
+    *
+    * @return amountEthReturn       Amount of ether returned to the caller
+    */
+    function issueExactSetFromToken(
+        ISetToken _setToken,
+        IERC20 _inputToken,
+        uint256 _amountSetToken,
+        uint256 _maxAmountInputToken
+    )
+        isSetToken(_setToken)
+        external
+        nonReentrant
+        returns (uint256)
+    {
+        require(_amountSetToken > 0 && _maxAmountInputToken > 0, "ExchangeIssuance: INVALID INPUTS");
+
+        _inputToken.safeTransferFrom(msg.sender, address(this), _maxAmountInputToken);
+
+        uint256 initETHAmount = address(_inputToken) == WETH
+            ? _maxAmountInputToken
+            : _swapTokenForWETH(_inputToken, _maxAmountInputToken);
+
+        uint256 amountEthSpent = _issueExactSetFromWETH(_setToken, _amountSetToken, initETHAmount);
+
+        uint256 amountEthReturn = initETHAmount.sub(amountEthSpent);
+        if (amountEthReturn > 0) {
+            IERC20(WETH).safeTransfer(msg.sender,  amountEthReturn);
+        }
+
+        emit Refund(msg.sender, amountEthReturn);
+        emit ExchangeIssue(msg.sender, _setToken, _inputToken, _maxAmountInputToken, _amountSetToken);
+        return amountEthReturn;
+    }
+
+    /**
+     * Redeems an exact amount of SetTokens for an ERC20 token.
+     * The SetToken must be approved by the sender to this contract.
+     *
+     * @param _setToken             Address of the SetToken being redeemed
+     * @param _outputToken          Address of output token
+     * @param _amountSetToken       Amount SetTokens to redeem
+     * @param _minOutputReceive     Minimum amount of output token to receive
+     *
+     * @return outputAmount         Amount of output tokens sent to the caller
+     */
+    function redeemExactSetForToken(
+        ISetToken _setToken,
+        IERC20 _outputToken,
+        uint256 _amountSetToken,
+        uint256 _minOutputReceive
+    )
+        isSetToken(_setToken)
+        external
+        nonReentrant
+        returns (uint256)
+    {
+        require(_amountSetToken > 0, "ExchangeIssuance: INVALID INPUTS");
+
+        address[] memory components = _setToken.getComponents();
+        (
+            uint256 totalEth,
+            uint256[] memory amountComponents,
+            Exchange[] memory exchanges
+        ) =  _getAmountETHForRedemption(_setToken, components, _amountSetToken);
+
+        uint256 outputAmount;
+        if (address(_outputToken) == WETH) {
+            require(totalEth > _minOutputReceive, "ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+            _redeemExactSet(_setToken, _amountSetToken);
+            outputAmount = _liquidateComponentsForWETH(components, amountComponents, exchanges);
+        } else {
+            (uint256 totalOutput, Exchange outTokenExchange, ) = _getMaxTokenForExactToken(totalEth, address(WETH), address(_outputToken));
+            require(totalOutput > _minOutputReceive, "ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+            _redeemExactSet(_setToken, _amountSetToken);
+            uint256 outputEth = _liquidateComponentsForWETH(components, amountComponents, exchanges);
+            outputAmount = _swapExactTokensForTokens(outTokenExchange, WETH, address(_outputToken), outputEth);
+        }
+
+        _outputToken.safeTransfer(msg.sender, outputAmount);
+        emit ExchangeRedeem(msg.sender, _setToken, _outputToken, _amountSetToken, outputAmount);
+        return outputAmount;
+    }
+
+
+    /**
+     * Returns an estimated amount of SetToken that can be issued given an amount of input ERC20 token.
+     *
+     * @param _setToken         Address of the SetToken being issued
+     * @param _amountInput      Amount of the input token to spend
+     * @param _inputToken       Address of input token.
+     *
+     * @return                  Estimated amount of SetTokens that will be received
+     */
+    function getEstimatedIssueSetAmount(
+        ISetToken _setToken,
+        IERC20 _inputToken,
+        uint256 _amountInput
+    )
+        isSetToken(_setToken)
+        external
+        view
+        returns (uint256)
+    {
+        require(_amountInput > 0, "ExchangeIssuance: INVALID INPUTS");
+
+        uint256 amountEth;
+        if (address(_inputToken) != WETH) {
+            // get max amount of WETH for the `_amountInput` amount of input tokens
+            (amountEth, , ) = _getMaxTokenForExactToken(_amountInput, address(_inputToken), WETH);
+        } else {
+            amountEth = _amountInput;
+        }
+
+        address[] memory components = _setToken.getComponents();
+        (uint256 setIssueAmount, , ) = _getSetIssueAmountForETH(_setToken, components, amountEth);
+        return setIssueAmount;
+    }
+
+    /**
+    * Returns the amount of input ERC20 tokens required to issue an exact amount of SetTokens.
+    *
+    * @param _setToken          Address of the SetToken being issued
+    * @param _amountSetToken    Amount of SetTokens to issue
+    *
+    * @return                   Amount of tokens needed to issue specified amount of SetTokens
+    */
+    function getAmountInToIssueExactSet(
+        ISetToken _setToken,
+        IERC20 _inputToken,
+        uint256 _amountSetToken
+    )
+        isSetToken(_setToken)
+        external
+        view
+        returns(uint256)
+    {
+        require(_amountSetToken > 0, "ExchangeIssuance: INVALID INPUTS");
+
+        address[] memory components = _setToken.getComponents();
+        (uint256 totalEth, , , , ) = _getAmountETHForIssuance(_setToken, components, _amountSetToken);
+
+        if (address(_inputToken) == WETH) {
+            return totalEth;
+        }
+
+        (uint256 tokenAmount, , ) = _getMinTokenForExactToken(totalEth, address(_inputToken), address(WETH));
+        return tokenAmount;
+    }
+
+    /**
+     * Returns amount of output ERC20 tokens received upon redeeming a given amount of SetToken.
+     *
+     * @param _setToken             Address of SetToken to be redeemed
+     * @param _amountSetToken       Amount of SetToken to be redeemed
+     * @param _outputToken          Address of output token
+     *
+     * @return                      Estimated amount of ether/erc20 that will be received
+     */
+    function getAmountOutOnRedeemSet(
+        ISetToken _setToken,
+        address _outputToken,
+        uint256 _amountSetToken
+    )
+        isSetToken(_setToken)
+        external
+        view
+        returns (uint256)
+    {
+        require(_amountSetToken > 0, "ExchangeIssuance: INVALID INPUTS");
+
+        address[] memory components = _setToken.getComponents();
+        (uint256 totalEth, , ) = _getAmountETHForRedemption(_setToken, components, _amountSetToken);
+
+        if (_outputToken == WETH) {
+            return totalEth;
+        }
+
+        // get maximum amount of tokens for totalEth amount of ETH
+        (uint256 tokenAmount, , ) = _getMaxTokenForExactToken(totalEth, WETH, _outputToken);
+        return tokenAmount;
+    }
+
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * Sets a max approval limit for an ERC20 token, provided the current allowance
+     * is less than the required allownce.
+     *
+     * @param _token    Token to approve
+     * @param _spender  Spender address to approve
+     */
+    function _safeApprove(IERC20 _token, address _spender, uint256 _requiredAllowance) internal {
+        uint256 allowance = _token.allowance(address(this), _spender);
+        if (allowance < _requiredAllowance) {
+            _token.safeIncreaseAllowance(_spender, MAX_UINT96 - allowance);
+        }
+    }
+
+    /**
+     * Issues SetTokens for an exact amount of input WETH.
+     *
+     * @param _setToken         Address of the SetToken being issued
+     * @param _minSetReceive    Minimum amount of index to receive
+     * @param _totalEthAmount   Total amount of WETH to be used to purchase the SetToken components
+     *
+     * @return setTokenAmount   Amount of SetTokens issued
+     */
+    function _issueSetForExactWETH(ISetToken _setToken, uint256 _minSetReceive, uint256 _totalEthAmount) internal returns (uint256) {
+
+        address[] memory components = _setToken.getComponents();
+        (
+            uint256 setIssueAmount,
+            uint256[] memory amountEthIn,
+            Exchange[] memory exchanges
+        ) = _getSetIssueAmountForETH(_setToken, components, _totalEthAmount);
+
+        require(setIssueAmount > _minSetReceive, "ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+
+        for (uint256 i = 0; i < components.length; i++) {
+            _swapExactTokensForTokens(exchanges[i], WETH, components[i], amountEthIn[i]);
+        }
+
+        basicIssuanceModule.issue(_setToken, setIssueAmount, msg.sender);
+        return setIssueAmount;
+    }
+
+    /**
+     * Issues an exact amount of SetTokens using WETH.
+     * Acquires SetToken components at the best price accross uniswap and sushiswap.
+     * Uses the acquired components to issue the SetTokens.
+     *
+     * @param _setToken          Address of the SetToken being issued
+     * @param _amountSetToken    Amount of SetTokens to be issued
+     * @param _maxEther          Max amount of ether that can be used to acquire the SetToken components
+     *
+     * @return totalEth          Total amount of ether used to acquire the SetToken components
+     */
+    function _issueExactSetFromWETH(ISetToken _setToken, uint256 _amountSetToken, uint256 _maxEther) internal returns (uint256) {
+
+        address[] memory components = _setToken.getComponents();
+        (
+            uint256 sumEth,
+            ,
+            Exchange[] memory exchanges,
+            uint256[] memory amountComponents,
+        ) = _getAmountETHForIssuance(_setToken, components, _amountSetToken);
+
+        require(sumEth <= _maxEther, "ExchangeIssuance: INSUFFICIENT_INPUT_AMOUNT");
+
+        uint256 totalEth = 0;
+        for (uint256 i = 0; i < components.length; i++) {
+            uint256 amountEth = _swapTokensForExactTokens(exchanges[i], WETH, components[i], amountComponents[i]);
+            totalEth = totalEth.add(amountEth);
+        }
+        basicIssuanceModule.issue(_setToken, _amountSetToken, msg.sender);
+        return totalEth;
+    }
+
+    /**
+     * Redeems a given amount of SetToken.
+     *
+     * @param _setToken     Address of the SetToken to be redeemed
+     * @param _amount       Amount of SetToken to be redeemed
+     */
+    function _redeemExactSet(ISetToken _setToken, uint256 _amount) internal returns (uint256) {
+        _setToken.safeTransferFrom(msg.sender, address(this), _amount);
+        basicIssuanceModule.redeem(_setToken, _amount, address(this));
+    }
+
+    /**
+     * Liquidates a given list of SetToken components for WETH.
+     *
+     * @param _components           An array containing the address of SetToken components
+     * @param _amountComponents     An array containing the amount of each SetToken component
+     * @param _exchanges            An array containing the exchange on which to liquidate the SetToken component
+     *
+     * @return                      Total amount of WETH received after liquidating all SetToken components
+     */
+    function _liquidateComponentsForWETH(address[] memory _components, uint256[] memory _amountComponents, Exchange[] memory _exchanges)
+        internal
+        returns (uint256)
+    {
+        uint256 sumEth = 0;
+        for (uint256 i = 0; i < _components.length; i++) {
+            sumEth = _exchanges[i] == Exchange.None
+                ? sumEth.add(_amountComponents[i])
+                : sumEth.add(_swapExactTokensForTokens(_exchanges[i], _components[i], WETH, _amountComponents[i]));
+        }
+        return sumEth;
+    }
+
+    /**
+     * Gets the total amount of ether required for purchasing each component in a SetToken,
+     * to enable the issuance of a given amount of SetTokens.
+     *
+     * @param _setToken             Address of the SetToken to be issued
+     * @param _components           An array containing the addresses of the SetToken components
+     * @param _amountSetToken       Amount of SetToken to be issued
+     *
+     * @return sumEth               The total amount of Ether reuired to issue the set
+     * @return amountEthIn          An array containing the amount of ether to purchase each component of the SetToken
+     * @return exchanges            An array containing the exchange on which to perform the purchase
+     * @return amountComponents     An array containing the amount of each SetToken component required for issuing the given
+     *                              amount of SetToken
+     * @return pairAddresses        An array containing the pair addresses of ETH/component exchange pool
+     */
+    function _getAmountETHForIssuance(ISetToken _setToken, address[] memory _components, uint256 _amountSetToken)
+        internal
+        view
+        returns (
+            uint256 sumEth,
+            uint256[] memory amountEthIn,
+            Exchange[] memory exchanges,
+            uint256[] memory amountComponents,
+            address[] memory pairAddresses
+        )
+    {
+        sumEth = 0;
+        amountEthIn = new uint256[](_components.length);
+        amountComponents = new uint256[](_components.length);
+        exchanges = new Exchange[](_components.length);
+        pairAddresses = new address[](_components.length);
+
+        for (uint256 i = 0; i < _components.length; i++) {
+
+            // Check that the component does not have external positions
+            require(
+                _setToken.getExternalPositionModules(_components[i]).length == 0,
+                "ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
+            );
+
+            // Get minimum amount of ETH to be spent to acquire the required amount of SetToken component
+            uint256 unit = uint256(_setToken.getDefaultPositionRealUnit(_components[i]));
+            amountComponents[i] = uint256(unit).preciseMulCeil(_amountSetToken);
+
+            (amountEthIn[i], exchanges[i], pairAddresses[i]) = _getMinTokenForExactToken(amountComponents[i], WETH, _components[i]);
+            sumEth = sumEth.add(amountEthIn[i]);
+        }
+        return (sumEth, amountEthIn, exchanges, amountComponents, pairAddresses);
+    }
+
+    /**
+     * Gets the total amount of ether returned from liquidating each component in a SetToken.
+     *
+     * @param _setToken             Address of the SetToken to be redeemed
+     * @param _components           An array containing the addresses of the SetToken components
+     * @param _amountSetToken       Amount of SetToken to be redeemed
+     *
+     * @return sumEth               The total amount of Ether that would be obtained from liquidating the SetTokens
+     * @return amountComponents     An array containing the amount of SetToken component to be liquidated
+     * @return exchanges            An array containing the exchange on which to liquidate the SetToken components
+     */
+    function _getAmountETHForRedemption(ISetToken _setToken, address[] memory _components, uint256 _amountSetToken)
+        internal
+        view
+        returns (uint256, uint256[] memory, Exchange[] memory)
+    {
+        uint256 sumEth = 0;
+        uint256 amountEth = 0;
+
+        uint256[] memory amountComponents = new uint256[](_components.length);
+        Exchange[] memory exchanges = new Exchange[](_components.length);
+
+        for (uint256 i = 0; i < _components.length; i++) {
+
+            // Check that the component does not have external positions
+            require(
+                _setToken.getExternalPositionModules(_components[i]).length == 0,
+                "ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED"
+            );
+
+            uint256 unit = uint256(_setToken.getDefaultPositionRealUnit(_components[i]));
+            amountComponents[i] = unit.preciseMul(_amountSetToken);
+
+            // get maximum amount of ETH received for a given amount of SetToken component
+            (amountEth, exchanges[i], ) = _getMaxTokenForExactToken(amountComponents[i], _components[i], WETH);
+            sumEth = sumEth.add(amountEth);
+        }
+        return (sumEth, amountComponents, exchanges);
+    }
+
+    /**
+     * Returns an estimated amount of SetToken that can be issued given an amount of input ERC20 token.
+     *
+     * @param _setToken             Address of the SetToken to be issued
+     * @param _components           An array containing the addresses of the SetToken components
+     * @param _amountEth            Total amount of ether available for the purchase of SetToken components
+     *
+     * @return setIssueAmount       The max amount of SetTokens that can be issued
+     * @return amountEthIn          An array containing the amount ether required to purchase each SetToken component
+     * @return exchanges            An array containing the exchange on which to purchase the SetToken components
+     */
+    function _getSetIssueAmountForETH(ISetToken _setToken, address[] memory _components, uint256 _amountEth)
+        internal
+        view
+        returns (uint256 setIssueAmount, uint256[] memory amountEthIn, Exchange[] memory exchanges)
+    {
+        uint256 sumEth;
+        uint256[] memory unitAmountEthIn;
+        uint256[] memory unitAmountComponents;
+        address[] memory pairAddresses;
+        (
+            sumEth,
+            unitAmountEthIn,
+            exchanges,
+            unitAmountComponents,
+            pairAddresses
+        ) = _getAmountETHForIssuance(_setToken, _components, PreciseUnitMath.preciseUnit());
+
+        setIssueAmount = PreciseUnitMath.maxUint256();
+        amountEthIn = new uint256[](_components.length);
+
+        for (uint256 i = 0; i < _components.length; i++) {
+
+            amountEthIn[i] = unitAmountEthIn[i].mul(_amountEth).div(sumEth);
+
+            uint256 amountComponent;
+            if (exchanges[i] == Exchange.None) {
+                amountComponent = amountEthIn[i];
+            } else {
+                (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(pairAddresses[i], WETH, _components[i]);
+                amountComponent = UniSushiV2Library.getAmountOut(amountEthIn[i], reserveIn, reserveOut);
+            }
+            setIssueAmount = Math.min(amountComponent.preciseDiv(unitAmountComponents[i]), setIssueAmount);
+        }
+        return (setIssueAmount, amountEthIn, exchanges);
+    }
+
+    /**
+     * Swaps a given amount of an ERC20 token for WETH for the best price on Uniswap/Sushiswap.
+     *
+     * @param _token    Address of the ERC20 token to be swapped for WETH
+     * @param _amount   Amount of ERC20 token to be swapped
+     *
+     * @return          Amount of WETH received after the swap
+     */
+    function _swapTokenForWETH(IERC20 _token, uint256 _amount) internal returns (uint256) {
+        (, Exchange exchange, ) = _getMaxTokenForExactToken(_amount, address(_token), WETH);
+        IUniswapV2Router02 router = _getRouter(exchange);
+        _safeApprove(_token, address(router), _amount);
+        return _swapExactTokensForTokens(exchange, address(_token), WETH, _amount);
+    }
+
+    /**
+     * Swap exact tokens for another token on a given DEX.
+     *
+     * @param _exchange     The exchange on which to peform the swap
+     * @param _tokenIn      The address of the input token
+     * @param _tokenOut     The address of the output token
+     * @param _amountIn     The amount of input token to be spent
+     *
+     * @return              The amount of output tokens
+     */
+    function _swapExactTokensForTokens(Exchange _exchange, address _tokenIn, address _tokenOut, uint256 _amountIn) internal returns (uint256) {
+        if (_tokenIn == _tokenOut) {
+            return _amountIn;
+        }
+        address[] memory path = new address[](2);
+        path[0] = _tokenIn;
+        path[1] = _tokenOut;
+        return _getRouter(_exchange).swapExactTokensForTokens(_amountIn, 0, path, address(this), block.timestamp)[1];
+    }
+
+    /**
+     * Swap tokens for exact amount of output tokens on a given DEX.
+     *
+     * @param _exchange     The exchange on which to peform the swap
+     * @param _tokenIn      The address of the input token
+     * @param _tokenOut     The address of the output token
+     * @param _amountOut    The amount of output token required
+     *
+     * @return              The amount of input tokens spent
+     */
+    function _swapTokensForExactTokens(Exchange _exchange, address _tokenIn, address _tokenOut, uint256 _amountOut) internal returns (uint256) {
+        if (_tokenIn == _tokenOut) {
+            return _amountOut;
+        }
+        address[] memory path = new address[](2);
+        path[0] = _tokenIn;
+        path[1] = _tokenOut;
+        return _getRouter(_exchange).swapTokensForExactTokens(_amountOut, PreciseUnitMath.maxUint256(), path, address(this), block.timestamp)[0];
+    }
+
+    /**
+     * Compares the amount of token required for an exact amount of another token across both exchanges,
+     * and returns the min amount.
+     *
+     * @param _amountOut    The amount of output token
+     * @param _tokenA       The address of tokenA
+     * @param _tokenB       The address of tokenB
+     *
+     * @return              The min amount of tokenA required across both exchanges
+     * @return              The Exchange on which minimum amount of tokenA is required
+     * @return              The pair address of the uniswap/sushiswap pool containing _tokenA and _tokenB
+     */
+    function _getMinTokenForExactToken(uint256 _amountOut, address _tokenA, address _tokenB) internal view returns (uint256, Exchange, address) {
+        if (_tokenA == _tokenB) {
+            return (_amountOut, Exchange.None, ETH_ADDRESS);
+        }
+
+        uint256 maxIn = PreciseUnitMath.maxUint256() ;
+        uint256 uniTokenIn = maxIn;
+        uint256 sushiTokenIn = maxIn;
+
+        address uniswapPair = _getPair(uniFactory, _tokenA, _tokenB);
+        if (uniswapPair != address(0)) {
+            (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(uniswapPair, _tokenA, _tokenB);
+            // Prevent subtraction overflow by making sure pool reserves are greater than swap amount
+            if (reserveOut > _amountOut) {
+                uniTokenIn = UniSushiV2Library.getAmountIn(_amountOut, reserveIn, reserveOut);
+            }
+        }
+
+        address sushiswapPair = _getPair(sushiFactory, _tokenA, _tokenB);
+        if (sushiswapPair != address(0)) {
+            (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(sushiswapPair, _tokenA, _tokenB);
+            // Prevent subtraction overflow by making sure pool reserves are greater than swap amount
+            if (reserveOut > _amountOut) {
+                sushiTokenIn = UniSushiV2Library.getAmountIn(_amountOut, reserveIn, reserveOut);
+            }
+        }
+
+        // Fails if both the values are maxIn
+        require(!(uniTokenIn == maxIn && sushiTokenIn == maxIn), "ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        return (uniTokenIn <= sushiTokenIn) ? (uniTokenIn, Exchange.Uniswap, uniswapPair) : (sushiTokenIn, Exchange.Sushiswap, sushiswapPair);
+    }
+
+    /**
+     * Compares the amount of token received for an exact amount of another token across both exchanges,
+     * and returns the max amount.
+     *
+     * @param _amountIn     The amount of input token
+     * @param _tokenA       The address of tokenA
+     * @param _tokenB       The address of tokenB
+     *
+     * @return              The max amount of tokens that can be received across both exchanges
+     * @return              The Exchange on which maximum amount of token can be received
+     * @return              The pair address of the uniswap/sushiswap pool containing _tokenA and _tokenB
+     */
+    function _getMaxTokenForExactToken(uint256 _amountIn, address _tokenA, address _tokenB) internal view returns (uint256, Exchange, address) {
+        if (_tokenA == _tokenB) {
+            return (_amountIn, Exchange.None, ETH_ADDRESS);
+        }
+
+        uint256 uniTokenOut = 0;
+        uint256 sushiTokenOut = 0;
+
+        address uniswapPair = _getPair(uniFactory, _tokenA, _tokenB);
+        if(uniswapPair != address(0)) {
+            (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(uniswapPair, _tokenA, _tokenB);
+            uniTokenOut = UniSushiV2Library.getAmountOut(_amountIn, reserveIn, reserveOut);
+        }
+
+        address sushiswapPair = _getPair(sushiFactory, _tokenA, _tokenB);
+        if(sushiswapPair != address(0)) {
+            (uint256 reserveIn, uint256 reserveOut) = UniSushiV2Library.getReserves(sushiswapPair, _tokenA, _tokenB);
+            sushiTokenOut = UniSushiV2Library.getAmountOut(_amountIn, reserveIn, reserveOut);
+        }
+
+        // Fails if both the values are 0
+        require(!(uniTokenOut == 0 && sushiTokenOut == 0), "ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        return (uniTokenOut >= sushiTokenOut) ? (uniTokenOut, Exchange.Uniswap, uniswapPair) : (sushiTokenOut, Exchange.Sushiswap, sushiswapPair);
+    }
+
+    /**
+     * Returns the pair address for on a given DEX.
+     *
+     * @param _factory   The factory to address
+     * @param _tokenA    The address of tokenA
+     * @param _tokenB    The address of tokenB
+     *
+     * @return           The pair address (Note: address(0) is returned by default if the pair is not available on that DEX)
+     */
+    function _getPair(address _factory, address _tokenA, address _tokenB) internal view returns (address) {
+        return IUniswapV2Factory(_factory).getPair(_tokenA, _tokenB);
+    }
+
+    /**
+     * Returns the router address of a given exchange.
+     *
+     * @param _exchange     The Exchange whose router address is needed
+     *
+     * @return              IUniswapV2Router02 router of the given exchange
+     */
+     function _getRouter(Exchange _exchange) internal view returns(IUniswapV2Router02) {
+         return (_exchange == Exchange.Uniswap) ? uniRouter : sushiRouter;
+     }
+
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "prepack": "if [[ \"$(basename \"$PWD\")\" == \"index-coop-contracts\" ]]; then echo \"CANNOT PUBLISH FROM THIS REPO\"; exit 1; fi;",
     "rename-extensions": "for f in typechain/*.d.ts; do mv -- \"$f\" \"${f%.d.ts}.ts\"; done",
     "test": "npx hardhat test --network localhost",
+    "test:fast": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat test --network localhost --no-compile",
+    "test:fast:compile": "TS_NODE_TRANSPILE_ONLY=1 npx hardhat test --network localhost",
     "test:fork": "FORK=true npx hardhat test",
     "test:clean": "yarn clean && yarn build && yarn test",
     "transpile": "tsc",

--- a/test/exchangeIssuance/exchangeIssuanceV2.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceV2.spec.ts
@@ -1,0 +1,1580 @@
+import "module-alias/register";
+
+import { Address, Account } from "@utils/types";
+import { ADDRESS_ZERO, ZERO, MAX_UINT_256, MAX_UINT_96, MAX_INT_256, ONE } from "@utils/constants";
+import { ExchangeIssuanceV2, StandardTokenMock, WETH9 } from "@utils/contracts/index";
+import { UniswapV2Factory, UniswapV2Router02 } from "@utils/contracts/uniswap";
+import { SetToken } from "@utils/contracts/setV2";
+import DeployHelper from "@utils/deploys";
+import {
+  cacheBeforeEach,
+  ether,
+  getAccounts,
+  getLastBlockTimestamp,
+  getSetFixture,
+  getUniswapFixture,
+  getWaffleExpect,
+} from "@utils/index";
+import { UnitsUtils } from "@utils/common/unitsUtils";
+import { SetFixture } from "@utils/fixtures";
+import { UniswapFixture } from "@utils/fixtures";
+import { BigNumber, ContractTransaction } from "ethers";
+import {
+  getAllowances,
+  getIssueExactSetFromToken,
+  getIssueSetForExactToken,
+  getRedeemExactSetForToken,
+  getIssueExactSetFromTokenRefund,
+} from "@utils/common/exchangeIssuanceUtils";
+
+
+const expect = getWaffleExpect();
+
+
+describe("ExchangeIssuanceV2", async () => {
+  let owner: Account;
+  let user: Account;
+  let externalPositionModule: Account;
+  let setV2Setup: SetFixture;
+
+  let deployer: DeployHelper;
+  let setToken: SetToken;
+  let setTokenWithWeth: SetToken;
+
+  let exchangeIssuance: ExchangeIssuanceV2;
+
+  cacheBeforeEach(async () => {
+    [
+      owner,
+      user,
+      externalPositionModule,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSetFixture(owner.address);
+    await setV2Setup.initialize();
+
+    const daiUnits = BigNumber.from("23252699054621733");
+    const wbtcUnits = UnitsUtils.wbtc(1);
+    setToken = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address, setV2Setup.wbtc.address],
+      [daiUnits, wbtcUnits],
+      [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+    );
+
+    await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
+
+    const wethUnits = ether(0.5);
+    setTokenWithWeth = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address, setV2Setup.weth.address],
+      [daiUnits, wethUnits],
+      [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+    );
+
+    await setV2Setup.issuanceModule.initialize(setTokenWithWeth.address, ADDRESS_ZERO);
+  });
+
+  describe("#constructor", async () => {
+    let wethAddress: Address;
+    let uniswapFactory: UniswapV2Factory;
+    let uniswapRouter: UniswapV2Router02;
+    let sushiswapFactory: UniswapV2Factory;
+    let sushiswapRouter: UniswapV2Router02;
+    let controllerAddress: Address;
+    let basicIssuanceModuleAddress: Address;
+
+    cacheBeforeEach(async () => {
+      let uniswapSetup: UniswapFixture;
+      let sushiswapSetup: UniswapFixture;
+      let wbtcAddress: Address;
+      let daiAddress: Address;
+
+      wethAddress = setV2Setup.weth.address;
+      wbtcAddress = setV2Setup.wbtc.address;
+      daiAddress = setV2Setup.dai.address;
+
+      uniswapSetup = getUniswapFixture(owner.address);
+      await uniswapSetup.initialize(owner, wethAddress, wbtcAddress, daiAddress);
+
+      sushiswapSetup = getUniswapFixture(owner.address);
+      await sushiswapSetup.initialize(owner, wethAddress, wbtcAddress, daiAddress);
+
+      uniswapFactory = uniswapSetup.factory;
+      uniswapRouter = uniswapSetup.router;
+      sushiswapFactory = sushiswapSetup.factory;
+      sushiswapRouter = sushiswapSetup.router;
+      controllerAddress = setV2Setup.controller.address;
+      basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
+    });
+
+    async function subject(): Promise<ExchangeIssuanceV2> {
+      return await deployer.adapters.deployExchangeIssuanceV2(
+        wethAddress,
+        uniswapFactory.address,
+        uniswapRouter.address,
+        sushiswapFactory.address,
+        sushiswapRouter.address,
+        controllerAddress,
+        basicIssuanceModuleAddress
+      );
+    }
+
+    it("verify state set properly via constructor", async () => {
+      const exchangeIssuanceContract: ExchangeIssuanceV2 = await subject();
+
+      const expectedWethAddress = await exchangeIssuanceContract.WETH();
+      expect(expectedWethAddress).to.eq(wethAddress);
+
+      const expectedUniRouterAddress = await exchangeIssuanceContract.uniRouter();
+      expect(expectedUniRouterAddress).to.eq(uniswapRouter.address);
+
+      const expectedUniFactoryAddress = await exchangeIssuanceContract.uniFactory();
+      expect(expectedUniFactoryAddress).to.eq(uniswapFactory.address);
+
+      const expectedSushiRouterAddress = await exchangeIssuanceContract.sushiRouter();
+      expect(expectedSushiRouterAddress).to.eq(sushiswapRouter.address);
+
+      const expectedSushiFactoryAddress = await exchangeIssuanceContract.sushiFactory();
+      expect(expectedSushiFactoryAddress).to.eq(sushiswapFactory.address);
+
+      const expectedControllerAddress = await exchangeIssuanceContract.setController();
+      expect(expectedControllerAddress).to.eq(controllerAddress);
+
+      const expectedBasicIssuanceModuleAddress = await exchangeIssuanceContract.basicIssuanceModule();
+      expect(expectedBasicIssuanceModuleAddress).to.eq(basicIssuanceModuleAddress);
+    });
+
+    it("approves WETH to the uniswap and sushiswap router", async () => {
+      const exchangeIssuance: ExchangeIssuanceV2 = await subject();
+
+      // validate the allowance of WETH between uniswap, sushiswap, and the deployed exchange issuance contract
+      const uniswapWethAllowance = await setV2Setup.weth.allowance(exchangeIssuance.address, uniswapRouter.address);
+      expect(uniswapWethAllowance).to.eq(MAX_UINT_256);
+
+      const sushiswapWethAllownace = await setV2Setup.weth.allowance(exchangeIssuance.address, sushiswapRouter.address);
+      expect(sushiswapWethAllownace).to.eq(MAX_UINT_256);
+
+    });
+  });
+
+  context("when exchange issuance is deployed", async () => {
+    let subjectWethAddress: Address;
+    let uniswapFactory: UniswapV2Factory;
+    let uniswapRouter: UniswapV2Router02;
+    let sushiswapFactory: UniswapV2Factory;
+    let sushiswapRouter: UniswapV2Router02;
+    let controllerAddress: Address;
+    let basicIssuanceModuleAddress: Address;
+
+    let weth: WETH9;
+    let wbtc: StandardTokenMock;
+    let dai: StandardTokenMock;
+    let usdc: StandardTokenMock;
+    let illiquidToken: StandardTokenMock;
+    let setTokenIlliquid: SetToken;
+    let setTokenExternal: SetToken;
+
+    cacheBeforeEach(async () => {
+      let uniswapSetup: UniswapFixture;
+      let sushiswapSetup: UniswapFixture;
+
+      weth = setV2Setup.weth;
+      wbtc = setV2Setup.wbtc;
+      dai = setV2Setup.dai;
+      usdc = setV2Setup.usdc;
+      illiquidToken = await deployer.setV2.deployTokenMock(owner.address, ether(1000000), 18, "illiquid token", "RUGGED");
+
+      usdc.transfer(user.address, UnitsUtils.usdc(10000));
+      weth.transfer(user.address, UnitsUtils.ether(1000));
+
+      const daiUnits = ether(0.5);
+      const illiquidTokenUnits = ether(0.5);
+      setTokenIlliquid = await setV2Setup.createSetToken(
+        [setV2Setup.dai.address, illiquidToken.address],
+        [daiUnits, illiquidTokenUnits],
+        [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+      );
+      await setV2Setup.issuanceModule.initialize(setTokenIlliquid.address, ADDRESS_ZERO);
+
+      setTokenExternal = await setV2Setup.createSetToken(
+        [setV2Setup.dai.address],
+        [ether(0.5)],
+        [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+      );
+      await setV2Setup.issuanceModule.initialize(setTokenExternal.address, ADDRESS_ZERO);
+
+      const controller = setV2Setup.controller;
+      await controller.addModule(externalPositionModule.address);
+      await setTokenExternal.addModule(externalPositionModule.address);
+      await setTokenExternal.connect(externalPositionModule.wallet).initializeModule();
+
+      await setTokenExternal.connect(externalPositionModule.wallet).addExternalPositionModule(
+        dai.address,
+        externalPositionModule.address
+      );
+
+      uniswapSetup = await getUniswapFixture(owner.address);
+      await uniswapSetup.initialize(owner, weth.address, wbtc.address, dai.address);
+      sushiswapSetup = await getUniswapFixture(owner.address);
+      await sushiswapSetup.initialize(owner, weth.address, wbtc.address, dai.address);
+
+      subjectWethAddress = weth.address;
+      uniswapFactory = uniswapSetup.factory;
+      uniswapRouter = uniswapSetup.router;
+      sushiswapFactory = sushiswapSetup.factory;
+      sushiswapRouter = sushiswapSetup.router;
+      controllerAddress = setV2Setup.controller.address;
+      basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
+
+      await sushiswapSetup.createNewPair(weth.address, wbtc.address);
+      await uniswapSetup.createNewPair(weth.address, dai.address);
+      await uniswapSetup.createNewPair(weth.address, usdc.address);
+
+      // ETH-WBTC pools
+      await wbtc.approve(uniswapRouter.address, MAX_UINT_256);
+      await uniswapRouter.connect(owner.wallet).addLiquidityETH(
+        wbtc.address,
+        UnitsUtils.wbtc(100000),
+        MAX_UINT_256,
+        MAX_UINT_256,
+        owner.address,
+        (await getLastBlockTimestamp()).add(1),
+        { value: ether(100), gasLimit: 9000000 }
+      );
+
+      // cheaper wbtc compared to uniswap
+      await wbtc.approve(sushiswapRouter.address, MAX_UINT_256);
+      await sushiswapRouter.connect(owner.wallet).addLiquidityETH(
+        wbtc.address,
+        UnitsUtils.wbtc(200000),
+        MAX_UINT_256,
+        MAX_UINT_256,
+        owner.address,
+        (await getLastBlockTimestamp()).add(1),
+        { value: ether(100), gasLimit: 9000000 }
+      );
+
+      // ETH-DAI pools
+      await dai.approve(uniswapRouter.address, MAX_INT_256);
+      await uniswapRouter.connect(owner.wallet).addLiquidityETH(
+        dai.address,
+        ether(100000),
+        MAX_UINT_256,
+        MAX_UINT_256,
+        owner.address,
+        (await getLastBlockTimestamp()).add(1),
+        { value: ether(10), gasLimit: 9000000 }
+      );
+
+      // ETH-USDC pools
+      await usdc.connect(owner.wallet).approve(uniswapRouter.address, MAX_INT_256);
+      await uniswapRouter.connect(owner.wallet).addLiquidityETH(
+        usdc.address,
+        UnitsUtils.usdc(100000),
+        MAX_UINT_256,
+        MAX_UINT_256,
+        user.address,
+        (await getLastBlockTimestamp()).add(1),
+        { value: ether(100), gasLimit: 9000000 }
+      );
+
+      exchangeIssuance = await deployer.adapters.deployExchangeIssuanceV2(
+        subjectWethAddress,
+        uniswapFactory.address,
+        uniswapRouter.address,
+        sushiswapFactory.address,
+        sushiswapRouter.address,
+        controllerAddress,
+        basicIssuanceModuleAddress
+      );
+    });
+
+    describe("#approveToken", async () => {
+
+      let subjectTokenToApprove: StandardTokenMock;
+
+      beforeEach(async () => {
+        subjectTokenToApprove = setV2Setup.dai;
+      });
+
+      async function subject(): Promise<ContractTransaction> {
+        return await exchangeIssuance.approveToken(subjectTokenToApprove.address);
+      }
+
+      it("should update the approvals correctly", async () => {
+        const spenders = [uniswapRouter.address, sushiswapRouter.address, basicIssuanceModuleAddress];
+        const tokens = [subjectTokenToApprove];
+
+        await subject();
+
+        const finalAllowances = await getAllowances(tokens, exchangeIssuance.address, spenders);
+
+        for (let i = 0; i < finalAllowances.length; i++) {
+          const actualAllowance = finalAllowances[i];
+          const expectedAllowance = MAX_UINT_96;
+          expect(actualAllowance).to.eq(expectedAllowance);
+        }
+      });
+    });
+
+    describe("#approveTokens", async () => {
+      let subjectTokensToApprove: StandardTokenMock[];
+
+      beforeEach(async () => {
+        subjectTokensToApprove = [setV2Setup.dai, setV2Setup.wbtc];
+      });
+
+      async function subject(): Promise<ContractTransaction> {
+        return await exchangeIssuance.approveTokens(subjectTokensToApprove.map(token => token.address));
+      }
+
+      it("should update the approvals correctly", async () => {
+        const spenders = [uniswapRouter.address, sushiswapRouter.address, basicIssuanceModuleAddress];
+
+        await subject();
+
+        const finalAllowances = await getAllowances(subjectTokensToApprove, exchangeIssuance.address, spenders);
+
+        for (let i = 0; i < finalAllowances.length; i++) {
+          const actualAllowance = finalAllowances[i];
+          const expectedAllowance = MAX_UINT_96;
+          expect(actualAllowance).to.eq(expectedAllowance);
+        }
+      });
+    });
+
+    describe("#approveSetToken", async () => {
+      let subjectSetToApprove: SetToken | StandardTokenMock;
+
+      beforeEach(async () => {
+        subjectSetToApprove = setToken;
+      });
+
+      async function subject(): Promise<ContractTransaction> {
+        return await exchangeIssuance.approveSetToken(subjectSetToApprove.address);
+      }
+
+      it("should update the approvals correctly", async () => {
+        const tokens = [dai, wbtc];
+        const spenders = [uniswapRouter.address, sushiswapRouter.address, basicIssuanceModuleAddress];
+
+        await subject();
+
+        const finalAllowances = await getAllowances(tokens, exchangeIssuance.address, spenders);
+
+        for (let i = 0; i < finalAllowances.length; i++) {
+          const actualAllowance = finalAllowances[i];
+          const expectedAllowance = MAX_UINT_96;
+          expect(actualAllowance).to.eq(expectedAllowance);
+        }
+      });
+
+      context("when the input token is not a set", async () => {
+        beforeEach(async () => {
+          subjectSetToApprove = usdc;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID SET");
+        });
+      });
+
+      context("when the set contains an external position", async () => {
+        beforeEach(async () => {
+          subjectSetToApprove = setTokenExternal;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED");
+        });
+      });
+    });
+
+    describe("#issueSetForExactToken", async () => {
+      let subjectCaller: Account;
+      let subjectSetToken: SetToken;
+      let subjectInputToken: StandardTokenMock | WETH9;
+      let subjectAmountInput: BigNumber;
+      let subjectMinSetReceive: BigNumber;
+
+      const initializeSubjectVariables = () => {
+        subjectCaller = user;
+        subjectSetToken = setToken;
+        subjectInputToken = usdc;
+        subjectAmountInput = UnitsUtils.usdc(1000);
+        subjectMinSetReceive = ether(0);
+      };
+
+      cacheBeforeEach(async () => {
+        initializeSubjectVariables();
+        await exchangeIssuance.approveSetToken(subjectSetToken.address);
+        await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256);
+      });
+
+      beforeEach(initializeSubjectVariables);
+
+      async function subject(): Promise<ContractTransaction> {
+        return await exchangeIssuance.connect(subjectCaller.wallet).issueSetForExactToken(
+          subjectSetToken.address,
+          subjectInputToken.address,
+          subjectAmountInput,
+          subjectMinSetReceive,
+          { gasLimit: 9000000 }
+        );
+      }
+
+      it("should issue the correct amount of Set to the caller", async () => {
+        const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+        const expectedOutputOfSet = await getIssueSetForExactToken(
+          subjectSetToken,
+          subjectInputToken.address,
+          subjectAmountInput,
+          uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
+          weth.address
+        );
+
+        await subject();
+
+        const finalSetBalance = await subjectSetToken.balanceOf(subjectCaller.address);
+        const expectedSetBalance = initialBalanceOfSet.add(expectedOutputOfSet);
+        expect(finalSetBalance).to.eq(expectedSetBalance);
+      });
+
+      it("should use the correct amount of input token from the caller", async () => {
+        const initialBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+
+        await subject();
+
+        const finalBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+        const expectedTokenBalance = initialBalanceOfInputToken.sub(subjectAmountInput);
+        expect(finalBalanceOfInputToken).to.eq(expectedTokenBalance);
+      });
+
+      it("emits an ExchangeIssue log", async () => {
+        const expectedSetTokenAmount = await getIssueSetForExactToken(
+          subjectSetToken,
+          subjectInputToken.address,
+          subjectAmountInput,
+          uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
+          weth.address
+        );
+
+        await expect(subject()).to.emit(exchangeIssuance, "ExchangeIssue").withArgs(
+          subjectCaller.address,
+          subjectSetToken.address,
+          subjectInputToken.address,
+          subjectAmountInput,
+          expectedSetTokenAmount
+        );
+      });
+
+      context("when input erc20 token is weth", async () => {
+        cacheBeforeEach(async () => {
+          subjectInputToken = weth;
+          await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+        });
+
+        it("should issue the correct amount of Set to the caller", async () => {
+          const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedOutputOfSet = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await subject();
+
+          const finalSetBalance = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedSetBalance = initialBalanceOfSet.add(expectedOutputOfSet);
+          expect(finalSetBalance).to.eq(expectedSetBalance);
+        });
+
+        it("should use the correct amount of input token from the caller", async () => {
+          const initialBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+          const expectedTokenBalance = initialBalanceOfInputToken.sub(subjectAmountInput);
+          expect(finalBalanceOfInputToken).to.eq(expectedTokenBalance);
+        });
+
+        it("emits an ExchangeIssue log", async () => {
+          const expectedSetTokenAmount = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await expect(subject()).to.emit(exchangeIssuance, "ExchangeIssue").withArgs(
+            subjectCaller.address,
+            subjectSetToken.address,
+            subjectInputToken.address,
+            subjectAmountInput,
+            expectedSetTokenAmount
+          );
+        });
+      });
+
+      context("when set contains weth", async () => {
+        cacheBeforeEach(async () => {
+          subjectSetToken = setTokenWithWeth;
+
+          await exchangeIssuance.approveSetToken(subjectSetToken.address);
+          await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256);
+        });
+
+        it("should issue the correct amount of Set to the caller", async () => {
+          const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedSetOutput = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await subject();
+
+          const finalSetBalance = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfSet.add(expectedSetOutput);
+          expect(finalSetBalance).to.eq(expectedBalance);
+        });
+
+        it("should use the correct amount of input token from the caller", async () => {
+          const initialBalanceOfToken = await subjectInputToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalTokenBalance = await subjectInputToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfToken.sub(subjectAmountInput);
+          expect(finalTokenBalance).to.eq(expectedBalance);
+        });
+
+        it("emits an ExchangeIssue log", async () => {
+          const expectedSetTokenAmount = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await expect(subject()).to.emit(exchangeIssuance, "ExchangeIssue").withArgs(
+            subjectCaller.address,
+            subjectSetToken.address,
+            subjectInputToken.address,
+            subjectAmountInput,
+            expectedSetTokenAmount
+          );
+        });
+      });
+
+      context("when input amount is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountInput = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when output set token amount is insufficient", async () => {
+        beforeEach(async () => {
+          subjectMinSetReceive = ether(100000);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+        });
+      });
+
+      context("when the set token has an illiquid component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenIlliquid;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+    });
+
+    describe("#issueExactSetFromToken", async () => {
+      let subjectCaller: Account;
+      let subjectSetToken: SetToken;
+      let subjectInputToken: StandardTokenMock | WETH9;
+      let subjectMaxAmountInput: BigNumber;
+      let subjectAmountSetToken: BigNumber;
+
+      const initializeSubjectVariables = () => {
+        subjectCaller = user;
+        subjectSetToken = setToken;
+        subjectInputToken = usdc;
+        subjectMaxAmountInput = UnitsUtils.usdc(100);
+        subjectAmountSetToken = ether(0.1);
+      };
+
+      cacheBeforeEach(async () => {
+        initializeSubjectVariables();
+        await exchangeIssuance.approveSetToken(subjectSetToken.address, { gasPrice: 0 });
+        await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+      });
+
+      beforeEach(initializeSubjectVariables);
+
+      async function subject(): Promise<ContractTransaction> {
+        return await exchangeIssuance.connect(subjectCaller.wallet).issueExactSetFromToken(
+          subjectSetToken.address,
+          subjectInputToken.address,
+          subjectAmountSetToken,
+          subjectMaxAmountInput,
+          { gasPrice: 0 }
+        );
+      }
+
+      it("should issue the correct amount of Set to the caller", async () => {
+        const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+
+        await subject();
+
+        const finalBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+        const expectBalanceOfSet = initialBalanceOfSet.add(subjectAmountSetToken);
+        expect(finalBalanceOfSet).to.eq(expectBalanceOfSet);
+      });
+
+      it("should use the correct amount of input token from the caller", async () => {
+        const initialBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+
+        await subject();
+
+        const finalBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+        const expectedBalanceOfInputToken = initialBalanceOfInputToken.sub(subjectMaxAmountInput);
+        expect(finalBalanceOfInputToken).to.eq(expectedBalanceOfInputToken);
+      });
+
+      it("should return the correct amount of ether to the caller", async () => {
+        const initialBalanceOfEth = await setV2Setup.weth.balanceOf(subjectCaller.address);
+        const expectedRefund = await getIssueExactSetFromTokenRefund(
+          subjectSetToken,
+          subjectInputToken,
+          subjectMaxAmountInput,
+          subjectAmountSetToken,
+          uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
+          weth.address
+        );
+
+        await subject();
+
+        const finalEthBalance = await setV2Setup.weth.balanceOf(subjectCaller.address);
+        const expectedEthBalance = initialBalanceOfEth.add(expectedRefund);
+        expect(finalEthBalance).to.eq(expectedEthBalance);
+      });
+
+      it("emits an ExchangeIssue log", async () => {
+        await expect(subject()).to.emit(exchangeIssuance, "ExchangeIssue").withArgs(
+          subjectCaller.address,
+          subjectSetToken.address,
+          subjectInputToken.address,
+          subjectMaxAmountInput,
+          subjectAmountSetToken
+        );
+      });
+
+      it("emits a Refund log", async () => {
+        const expectedRefund = await getIssueExactSetFromTokenRefund(
+          subjectSetToken,
+          subjectInputToken,
+          subjectMaxAmountInput,
+          subjectAmountSetToken,
+          uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
+          weth.address
+        );
+
+        await expect(subject()).to.emit(exchangeIssuance, "Refund").withArgs(
+          subjectCaller.address,
+          expectedRefund
+        );
+      });
+
+      context("when input erc20 token is weth", async () => {
+        const initializeSubjectVariables = () => {
+          subjectInputToken = weth;
+          subjectMaxAmountInput = UnitsUtils.ether(1000);
+          subjectAmountSetToken = UnitsUtils.ether(1);
+        };
+
+        cacheBeforeEach(async () => {
+          initializeSubjectVariables();
+          await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+        });
+
+        beforeEach(initializeSubjectVariables);
+
+        it("should issue the correct amount of Set to the caller", async () => {
+          const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectBalanceOfSet = initialBalanceOfSet.add(subjectAmountSetToken);
+          expect(finalBalanceOfSet).to.eq(expectBalanceOfSet);
+        });
+
+        it("should use the correct amount of input token from the caller", async () => {
+          const initialBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+
+          const amountIn = await exchangeIssuance.getAmountInToIssueExactSet(
+            subjectSetToken.address,
+            subjectInputToken.address,
+            subjectAmountSetToken
+          );
+
+          await subject();
+
+          const finalBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+          const expectedBalanceOfInputToken = initialBalanceOfInputToken.sub(amountIn);
+          expect(finalBalanceOfInputToken).to.eq(expectedBalanceOfInputToken);
+        });
+
+        it("should return the correct amount of WETH to the caller", async () => {
+          const initialBalanceOfWeth = await setV2Setup.weth.balanceOf(subjectCaller.address);
+
+          const amountIn = await exchangeIssuance.getAmountInToIssueExactSet(
+            subjectSetToken.address,
+            subjectInputToken.address,
+            subjectAmountSetToken
+          );
+
+          const expectedRefund = await getIssueExactSetFromTokenRefund(
+            subjectSetToken,
+            subjectInputToken,
+            subjectMaxAmountInput,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await subject();
+
+          const finalEthBalance = await setV2Setup.weth.balanceOf(subjectCaller.address);
+          const expectedEthBalance = initialBalanceOfWeth.sub(amountIn);
+
+          expect(finalEthBalance).to.eq(expectedEthBalance);
+          expect(finalEthBalance).to.eq(expectedRefund);
+        });
+
+        it("emits an ExchangeIssue log", async () => {
+          await expect(subject()).to.emit(exchangeIssuance, "ExchangeIssue").withArgs(
+            subjectCaller.address,
+            subjectSetToken.address,
+            subjectInputToken.address,
+            subjectMaxAmountInput,
+            subjectAmountSetToken
+          );
+        });
+
+        it("emits a Refund log", async () => {
+          const expectedRefund = await getIssueExactSetFromTokenRefund(
+            subjectSetToken,
+            subjectInputToken,
+            subjectMaxAmountInput,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await expect(subject()).to.emit(exchangeIssuance, "Refund").withArgs(
+            subjectCaller.address,
+            expectedRefund
+          );
+        });
+
+        context("when exact amount of token needed is supplied", () => {
+          beforeEach(async () => {
+            subjectMaxAmountInput = await getIssueExactSetFromToken(
+              subjectSetToken,
+              subjectInputToken,
+              subjectAmountSetToken,
+              uniswapRouter,
+              uniswapFactory,
+              sushiswapRouter,
+              sushiswapFactory,
+              weth.address
+            );
+          });
+
+          it("should not refund any eth", async () => {
+            await expect(subject()).to.emit(exchangeIssuance, "Refund").withArgs(
+              subjectCaller.address,
+              BigNumber.from(0)
+            );
+          });
+        });
+      });
+
+      context("when set contains weth", async () => {
+        cacheBeforeEach(async () => {
+          subjectSetToken = setTokenWithWeth;
+          subjectAmountSetToken = ether(0.00001);
+
+          await exchangeIssuance.approveSetToken(subjectSetToken.address, { gasPrice: 0 });
+          await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+        });
+
+        it("should issue the correct amount of Set to the caller", async () => {
+          const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfSet.add(subjectAmountSetToken);
+          expect(finalBalanceOfSet).to.eq(expectedBalance);
+        });
+
+        it("should use the correct amount of input token from the caller", async () => {
+          const initialBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalBalanceOfInputToken = await subjectInputToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfInputToken.sub(subjectMaxAmountInput);
+          expect(finalBalanceOfInputToken).to.eq(expectedBalance);
+        });
+
+        it("should return the correct amount of WETH to the caller", async () => {
+          const initialBalanceOfEth = await setV2Setup.weth.balanceOf(subjectCaller.address);
+          const expectedRefund = await getIssueExactSetFromTokenRefund(
+            subjectSetToken,
+            subjectInputToken,
+            subjectMaxAmountInput,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await subject();
+
+          const finalEthBalance = await setV2Setup.weth.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfEth.add(expectedRefund);
+          expect(finalEthBalance).to.eq(expectedBalance);
+        });
+
+        it("emits an ExchangeIssue log", async () => {
+          await expect(subject()).to.emit(exchangeIssuance, "ExchangeIssue").withArgs(
+            subjectCaller.address,
+            subjectSetToken.address,
+            subjectInputToken.address,
+            subjectMaxAmountInput,
+            subjectAmountSetToken
+          );
+        });
+
+        it("emits a Refund log", async () => {
+          const expectedRefund = await getIssueExactSetFromTokenRefund(
+            subjectSetToken,
+            subjectInputToken,
+            subjectMaxAmountInput,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await expect(subject()).to.emit(exchangeIssuance, "Refund").withArgs(
+            subjectCaller.address,
+            expectedRefund
+          );
+        });
+      });
+
+      context("when max input amount is 0", async () => {
+        beforeEach(async () => {
+          subjectMaxAmountInput = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when input token amount is insufficient", async () => {
+        beforeEach(async () => {
+          subjectMaxAmountInput = ONE;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_INPUT_AMOUNT");
+        });
+      });
+
+      context("when the set token has an illiquid component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenIlliquid;
+
+          await exchangeIssuance.approveSetToken(subjectSetToken.address, { gasPrice: 0 });
+          await subjectInputToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+
+      context("when there is not enough liquidity to issue required amount", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ether(10 ** 10);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+
+      context("when there is not enough liquidity to issue required amount (on sushi)", async () => {
+        beforeEach(async () => {
+          subjectSetToken = await setV2Setup.createSetToken(
+            [setV2Setup.wbtc.address],
+            [UnitsUtils.wbtc(1)],
+            [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+          );
+          subjectAmountSetToken = ether(10 ** 10);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+    });
+
+    describe("#redeemExactSetForToken", async () => {
+      let subjectCaller: Account;
+      let subjectSetToken: SetToken;
+      let subjectAmountSetToken: BigNumber;
+      let subjectOutputToken: StandardTokenMock | WETH9;
+      let subjectMinTokenReceived: BigNumber;
+
+      const initializeSubjectVariables = () => {
+        subjectCaller = user;
+        subjectSetToken = setToken;
+        subjectAmountSetToken = ether(100);
+        subjectOutputToken = usdc;
+        subjectMinTokenReceived = ether(0);
+      };
+
+      cacheBeforeEach(async () => {
+        initializeSubjectVariables();
+        // acquire set tokens to redeem
+        await setV2Setup.approveAndIssueSetToken(subjectSetToken, subjectAmountSetToken, subjectCaller.address);
+        await exchangeIssuance.approveSetToken(subjectSetToken.address);
+        await subjectSetToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+      });
+
+      beforeEach(initializeSubjectVariables);
+
+      async function subject(): Promise<ContractTransaction> {
+        return await exchangeIssuance.connect(subjectCaller.wallet).redeemExactSetForToken(
+          subjectSetToken.address,
+          subjectOutputToken.address,
+          subjectAmountSetToken,
+          subjectMinTokenReceived,
+          { gasPrice: 0 }
+        );
+      }
+
+      it("should redeem the correct amount of a set to the caller", async () => {
+        const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+
+        await subject();
+
+        const finalBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+        const expectedBalance = initialBalanceOfSet.sub(subjectAmountSetToken);
+        expect(finalBalanceOfSet).to.eq(expectedBalance);
+      });
+
+      it("should return the correct amount of output token to the caller", async () => {
+        const initialBalanceOfToken = await subjectOutputToken.balanceOf(subjectCaller.address);
+        const expectedTokensReturned = await getRedeemExactSetForToken(
+          subjectSetToken,
+          subjectOutputToken,
+          subjectAmountSetToken,
+          uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
+          weth.address
+        );
+
+        await subject();
+
+        const finalTokenBalance = await subjectOutputToken.balanceOf(subjectCaller.address);
+        const expectedBalance = initialBalanceOfToken.add(expectedTokensReturned);
+        expect(finalTokenBalance).to.eq(expectedBalance);
+      });
+
+      it("emits an ExchangeRedeem log", async () => {
+        const expectedTokensReturned = await getRedeemExactSetForToken(
+          subjectSetToken,
+          subjectOutputToken,
+          subjectAmountSetToken,
+          uniswapRouter,
+          uniswapFactory,
+          sushiswapRouter,
+          sushiswapFactory,
+          weth.address
+        );
+
+        await expect(subject()).to.emit(exchangeIssuance, "ExchangeRedeem").withArgs(
+          subjectCaller.address,
+          subjectSetToken.address,
+          subjectOutputToken.address,
+          subjectAmountSetToken,
+          expectedTokensReturned
+        );
+      });
+
+      context("when set token has external positions", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenExternal;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED");
+        });
+      });
+
+      context("when output erc20 token amount is insufficient", async () => {
+        beforeEach(async () => {
+          subjectMinTokenReceived = ether(100000);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+        });
+      });
+
+      context("when output erc20 token is weth", async () => {
+        beforeEach(async () => {
+          subjectOutputToken = weth;
+        });
+
+        it("should redeem the correct amount of a set to the caller", async () => {
+          const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfSet.sub(subjectAmountSetToken);
+          expect(finalBalanceOfSet).to.eq(expectedBalance);
+        });
+
+        it("should return the correct amount of output token to the caller", async () => {
+          const initialBalanceOfToken = await subjectOutputToken.balanceOf(subjectCaller.address);
+          const expectedTokensReturned = await getRedeemExactSetForToken(
+            subjectSetToken,
+            subjectOutputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await subject();
+
+          const finalTokenBalance = await subjectOutputToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfToken.add(expectedTokensReturned);
+          expect(finalTokenBalance).to.eq(expectedBalance);
+        });
+
+        context("when output erc20 token amount is insufficient", async () => {
+          beforeEach(async () => {
+            subjectMinTokenReceived = ether(100000);
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("ExchangeIssuance: INSUFFICIENT_OUTPUT_AMOUNT");
+          });
+        });
+      });
+
+      context("when set contains weth", async () => {
+        const initializeSubjectVariables = () => {
+          subjectSetToken = setTokenWithWeth;
+          subjectAmountSetToken = ether(1);
+        };
+
+        cacheBeforeEach(async () => {
+          initializeSubjectVariables();
+          await setV2Setup.approveAndIssueSetToken(subjectSetToken, subjectAmountSetToken, subjectCaller.address);
+          await exchangeIssuance.approveSetToken(subjectSetToken.address);
+          await subjectSetToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+        });
+
+        beforeEach(initializeSubjectVariables);
+
+        it("should redeem the correct amount of a set to the caller", async () => {
+          const initialBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+
+          await subject();
+
+          const finalBalanceOfSet = await subjectSetToken.balanceOf(subjectCaller.address);
+          const expectedBalanceOfSet = initialBalanceOfSet.sub(subjectAmountSetToken);
+          expect(finalBalanceOfSet).to.eq(expectedBalanceOfSet);
+        });
+
+        it("should return the correct amount of output token to the caller", async () => {
+          const initialBalanceOfToken = await subjectOutputToken.balanceOf(subjectCaller.address);
+          const expectedTokensReturned = await getRedeemExactSetForToken(
+            subjectSetToken,
+            subjectOutputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await subject();
+
+          const finalTokenBalance = await subjectOutputToken.balanceOf(subjectCaller.address);
+          const expectedBalance = initialBalanceOfToken.add(expectedTokensReturned);
+          expect(finalTokenBalance).to.eq(expectedBalance);
+        });
+
+        it("emits an ExchangeRedeem log", async () => {
+          const expectedTokensReturned = await getRedeemExactSetForToken(
+            subjectSetToken,
+            subjectOutputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+
+          await expect(subject()).to.emit(exchangeIssuance, "ExchangeRedeem").withArgs(
+            subjectCaller.address,
+            subjectSetToken.address,
+            subjectOutputToken.address,
+            subjectAmountSetToken,
+            expectedTokensReturned
+          );
+        });
+      });
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when the set token has an illiquid component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenIlliquid;
+          await setV2Setup.approveAndIssueSetToken(subjectSetToken, subjectAmountSetToken, subjectCaller.address);
+          await exchangeIssuance.approveSetToken(subjectSetToken.address);
+          await subjectSetToken.connect(subjectCaller.wallet).approve(exchangeIssuance.address, MAX_UINT_256, { gasPrice: 0 });
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+    });
+
+    describe("#getEstimatedIssueSetAmount", async () => {
+      let subjectSetToken: SetToken;
+      let subjectInputToken: StandardTokenMock | WETH9;
+      let subjectAmountInput: BigNumber;
+
+      beforeEach(async () => {
+        subjectSetToken = setToken;
+        subjectAmountInput = UnitsUtils.usdc(1000);
+      });
+
+      async function subject(): Promise<BigNumber> {
+        return await exchangeIssuance.getEstimatedIssueSetAmount(
+          subjectSetToken.address,
+          subjectInputToken.address,
+          subjectAmountInput
+        );
+      }
+
+      context("when input token is weth", async () => {
+        beforeEach(async () => {
+          subjectInputToken = weth;
+        });
+
+        it("should return the correct amount of output set", async () => {
+          const expectedSetOutput = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualSetOutput = await subject();
+
+          expect(expectedSetOutput).to.eq(actualSetOutput);
+        });
+      });
+
+      context("when input token is an erc20", async () => {
+        beforeEach(async () => {
+          subjectInputToken = usdc;
+        });
+
+        it("should return the correct amount of output set", async () => {
+          const expectedSetOutput = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualSetOutput = await subject();
+
+          expect(expectedSetOutput).to.eq(actualSetOutput);
+        });
+      });
+
+      context("when set contains an external component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenExternal;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: EXTERNAL_POSITIONS_NOT_ALLOWED");
+        });
+      });
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountInput = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when set contains weth", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenWithWeth;
+        });
+
+        it("should return the correct amount of output set", async () => {
+          const expectedSetOutput = await getIssueSetForExactToken(
+            subjectSetToken,
+            subjectInputToken.address,
+            subjectAmountInput,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualSetOutput = await subject();
+
+          expect(expectedSetOutput).to.eq(actualSetOutput);
+        });
+      });
+
+      context("when set contains an illiquid component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenIlliquid;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+    });
+
+    describe("#getAmountInToIssueExactSet", async () => {
+      let subjectSetToken: SetToken;
+      let subjectInputToken: StandardTokenMock | WETH9;
+      let subjectAmountSetToken: BigNumber;
+
+      beforeEach(async () => {
+        subjectSetToken = setToken;
+        subjectAmountSetToken = ether(1000);
+      });
+
+      async function subject(): Promise<BigNumber> {
+        return await exchangeIssuance.getAmountInToIssueExactSet(
+          subjectSetToken.address,
+          subjectInputToken.address,
+          subjectAmountSetToken
+        );
+      }
+
+      context("when input token is an erc20", async () => {
+        beforeEach(async () => {
+          subjectInputToken = usdc;
+        });
+
+        it("should return the correct amount of input tokens", async () => {
+          const expectedInputAmount = await getIssueExactSetFromToken(
+            subjectSetToken,
+            subjectInputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualInputAmount = await subject();
+
+          expect(expectedInputAmount).to.eq(actualInputAmount);
+        });
+      });
+
+      context("when input token is weth", async () => {
+        beforeEach(async () => {
+          subjectInputToken = weth;
+        });
+
+        it("should return the correct amount of input tokens", async () => {
+          const expectedInputAmount = await getIssueExactSetFromToken(
+            subjectSetToken,
+            subjectInputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualInputAmount = await subject();
+
+          expect(expectedInputAmount).to.eq(actualInputAmount);
+        });
+      });
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when set contains weth", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenWithWeth;
+        });
+
+        it("should return the correct amount of input tokens", async () => {
+          const expectedInputAmount = await getIssueExactSetFromToken(
+            subjectSetToken,
+            subjectInputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualInputAmount = await subject();
+
+          expect(expectedInputAmount).to.eq(actualInputAmount);
+        });
+      });
+
+      context("when set contains an illiquid component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenIlliquid;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+
+      context("when there is not enough liquidity to issue required amount", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ether(10 ** 10);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+    });
+
+    describe("#getAmountOutOnRedeemSet", async () => {
+      let subjectSetToken: SetToken;
+      let subjectOutputToken: StandardTokenMock | WETH9;
+      let subjectAmountSetToken: BigNumber;
+
+      beforeEach(async () => {
+        subjectSetToken = setToken;
+        subjectAmountSetToken = ether(100);
+        subjectOutputToken = usdc;
+      });
+
+      async function subject(): Promise<BigNumber> {
+        return await exchangeIssuance.getAmountOutOnRedeemSet(
+          subjectSetToken.address,
+          subjectOutputToken.address,
+          subjectAmountSetToken
+        );
+      }
+
+      context("when output is an erc20", async () => {
+        beforeEach(async () => {
+          subjectOutputToken = usdc;
+        });
+
+        it("should return the correct amount of output tokens", async () => {
+          const expectedOutputAmount = await getRedeemExactSetForToken(
+            subjectSetToken,
+            subjectOutputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualOutputAmount = await subject();
+
+          expect(expectedOutputAmount).to.eq(actualOutputAmount);
+        });
+      });
+
+      context("when output is weth", async () => {
+        beforeEach(async () => {
+          subjectOutputToken = weth;
+        });
+
+        it("should return the correct amount of output tokens", async () => {
+          const expectedOutputAmount = await getRedeemExactSetForToken(
+            subjectSetToken,
+            subjectOutputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualOutputAmount = await subject();
+
+          expect(expectedOutputAmount).to.eq(actualOutputAmount);
+        });
+      });
+
+      context("when set contains weth", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenWithWeth;
+        });
+
+        it("should return the correct amount of output tokens", async () => {
+          const expectedOutputAmount = await getRedeemExactSetForToken(
+            subjectSetToken,
+            subjectOutputToken,
+            subjectAmountSetToken,
+            uniswapRouter,
+            uniswapFactory,
+            sushiswapRouter,
+            sushiswapFactory,
+            weth.address
+          );
+          const actualOutputAmount = await subject();
+
+          expect(expectedOutputAmount).to.eq(actualOutputAmount);
+        });
+      });
+
+      context("when amount Set is 0", async () => {
+        beforeEach(async () => {
+          subjectAmountSetToken = ZERO;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID INPUTS");
+        });
+      });
+
+      context("when set contains an illiquid component", async () => {
+        beforeEach(async () => {
+          subjectSetToken = setTokenIlliquid;
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("ExchangeIssuance: ILLIQUID_SET_COMPONENT");
+        });
+      });
+    });
+  });
+});

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -3,6 +3,7 @@ export { ICManager } from "../../typechain/ICManager";
 export { BaseManager } from "../../typechain/BaseManager";
 export { TradeAdapterMock } from "../../typechain/TradeAdapterMock";
 export { ExchangeIssuance } from "../../typechain/ExchangeIssuance";
+export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
 export { FeeSplitAdapter } from "../../typechain/FeeSplitAdapter";
 export { FlexibleLeverageStrategyAdapter } from "../../typechain/FlexibleLeverageStrategyAdapter";
 export { SupplyCapIssuanceHook } from "../../typechain/SupplyCapIssuanceHook";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -1,10 +1,11 @@
 import { Signer, BigNumber } from "ethers";
 import { Address, ContractSettings, MethodologySettings, ExecutionSettings, IncentiveSettings } from "../types";
-import { FlexibleLeverageStrategyAdapter, FeeSplitAdapter, ExchangeIssuance } from "../contracts/index";
+import { FlexibleLeverageStrategyAdapter, FeeSplitAdapter, ExchangeIssuance, ExchangeIssuanceV2 } from "../contracts/index";
 
 import { FeeSplitAdapter__factory } from "../../typechain/factories/FeeSplitAdapter__factory";
 import { FlexibleLeverageStrategyAdapter__factory } from "../../typechain/factories/FlexibleLeverageStrategyAdapter__factory";
 import { ExchangeIssuance__factory } from "../../typechain/factories/ExchangeIssuance__factory";
+import { ExchangeIssuanceV2__factory } from "../../typechain/factories/ExchangeIssuanceV2__factory";
 
 export default class DeployAdapters {
   private _deployerSigner: Signer;
@@ -53,6 +54,26 @@ export default class DeployAdapters {
     basicIssuanceModuleAddress: Address,
   ): Promise<ExchangeIssuance> {
     return await new ExchangeIssuance__factory(this._deployerSigner).deploy(
+      wethAddress,
+      uniFactoryAddress,
+      uniRouterAddress,
+      sushiFactoryAddress,
+      sushiRouterAddress,
+      setControllerAddress,
+      basicIssuanceModuleAddress
+    );
+  }
+
+  public async deployExchangeIssuanceV2(
+    wethAddress: Address,
+    uniFactoryAddress: Address,
+    uniRouterAddress: Address,
+    sushiFactoryAddress: Address,
+    sushiRouterAddress: Address,
+    setControllerAddress: Address,
+    basicIssuanceModuleAddress: Address,
+  ): Promise<ExchangeIssuanceV2> {
+    return await new ExchangeIssuanceV2__factory(this._deployerSigner).deploy(
       wethAddress,
       uniFactoryAddress,
       uniRouterAddress,


### PR DESCRIPTION
PR adds a simplified variant of the ExchangeIssuance contract which has all native currency logic removed. 

The rationale for doing this is two-part:
+ non-ethereum chains have non-ETH native currencies. `ExchangeIssuance`'s WETH unwrapping logic becomes WMATIC unwrapping (or equivalent) when executed on a side chain. 
+ WETH is still the most liquid component in AMM pairs on the side chain we're targeting (Polygon). Substituting a native currency wrapper like WMATIC for WETH would impair trade performance. 

Contract changes here are:

**Method removals**
+ [receive][1]
+ [issueSetForExactETH][2]
+ [issueExactSetFromETH][3]
+ [redeemExactSetForETH][4]

[1]: https://github.com/SetProtocol/index-coop-smart-contracts/blob/7ef60ef3f007de8dd40a9cfcd0c0dd1e0a3b693c/contracts/exchangeIssuance/ExchangeIssuance.sol#L145-L148
[2]: https://github.com/SetProtocol/index-coop-smart-contracts/blob/7ef60ef3f007de8dd40a9cfcd0c0dd1e0a3b693c/contracts/exchangeIssuance/ExchangeIssuance.sol#L224-L242
[3]: https://github.com/SetProtocol/index-coop-smart-contracts/blob/7ef60ef3f007de8dd40a9cfcd0c0dd1e0a3b693c/contracts/exchangeIssuance/ExchangeIssuance.sol#L297-L323
[4]: https://github.com/SetProtocol/index-coop-smart-contracts/blob/7ef60ef3f007de8dd40a9cfcd0c0dd1e0a3b693c/contracts/exchangeIssuance/ExchangeIssuance.sol#L384-L414

**Logic changes**
 
The WETH redemption flow `issueExactSetFromToken` has been changed from "unwrap WETH and sendValue" to "WETH.transfer"

**Old**
https://github.com/SetProtocol/index-coop-smart-contracts/blob/ecef4a21cc6161c3651b72bc6da6ffa787af2dd7/contracts/exchangeIssuance/ExchangeIssuance.sol#L277-L281

**New**
https://github.com/SetProtocol/index-coop-smart-contracts/blob/7ef60ef3f007de8dd40a9cfcd0c0dd1e0a3b693c/contracts/exchangeIssuance/ExchangeIssuanceV2.sol#L243-L246

The only tests with substantive changes (apart from those removed) to accommodate the new behavior are in 

[exchangeIssuanceV2.spec.ts#L754-L798][5]

[5]: https://github.com/SetProtocol/index-coop-smart-contracts/blob/7ef60ef3f007de8dd40a9cfcd0c0dd1e0a3b693c/test/exchangeIssuance/exchangeIssuanceV2.spec.ts#L754-L798



