### PR TITLE
Stop importing hardhat in lib link generation utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/index-coop-contracts",
-  "version": "0.0.22",
+  "version": "0.0.25",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/utils/common/libraryUtils.ts
+++ b/utils/common/libraryUtils.ts
@@ -1,54 +1,16 @@
 import { utils } from "ethers";
-import { artifacts } from "hardhat";
-import { Artifact } from "hardhat/types";
 import path from "path";
-import globby from "globby";
 
-// If libraryName corresponds to more than one artifact (e.g there are
-// duplicate contract names in the project), `readArtifactSync`
-// will throw. In such cases it"s necessary to pass this method the fully qualified
-// contract name. ex: `contracts/mocks/LibraryMock.sol:LibraryMock`
+// Converts a fully qualified contract name in a bytecode link id.
+// (A fully qualified name looks like: `contracts/mocks/LibraryMock.sol:LibraryMock`)
 export function convertLibraryNameToLinkId(libraryName: string): string {
-  let artifact;
-  let fullyQualifiedName;
-
-  if (libraryName.includes(path.sep) && libraryName.includes(":")) {
-    fullyQualifiedName = libraryName;
-  } else {
-    artifact = getArtifact(libraryName);
-    fullyQualifiedName = `${artifact.sourceName}:${artifact.contractName}`;
-  }
-
-  const hashedName = utils.keccak256(utils.toUtf8Bytes(fullyQualifiedName));
-  return `__$${hashedName.slice(2).slice(0, 34)}$__`;
-}
-
-// Tries to resolve via hardhat artifacts helpers, then by searching for appropriately
-// named jsons in the root `external` folder
-function getArtifact(libraryName: string): Artifact {
-  try {
-    return artifacts.readArtifactSync(libraryName);
-  } catch (e) {
-    /* ignore */
-  }
-
-  const files = globby.sync("external", {
-    expandDirectories: { extensions: ["json"], },
-  });
-
-  const matches = files.filter(f => f.includes(`/${libraryName}.json`));
-
-  if (!matches.length) {
-    throw new Error(`Unable to find artifact for '${libraryName}' while linking.`);
-  }
-
-  if (matches.length > 1) {
+  if (!(libraryName.includes(path.sep) && libraryName.includes(":"))) {
     throw new Error(
-      `Unable to resolve '${libraryName}' while linking. ` +
-      `(More than one file name matches in 'external/')`
+      "Converting library name to link id requires a fully qualified " +
+      "contract name. Example: `contracts/mocks/LibraryMock.sol:LibraryMock`"
     );
   }
 
-  const pathToArtifact = path.join(process.cwd(), matches[0]);
-  return require(pathToArtifact);
+  const hashedName = utils.keccak256(utils.toUtf8Bytes(libraryName));
+  return `__$${hashedName.slice(2).slice(0, 34)}$__`;
 }

--- a/utils/deploys/deploySetV2.ts
+++ b/utils/deploys/deploySetV2.ts
@@ -148,7 +148,10 @@ export default class DeploySetV2 {
     weth: Address,
   ): Promise<CompoundLeverageModule> {
     const compoundLib = await this.deployCompoundLib();
-    const linkId = convertLibraryNameToLinkId("Compound");
+
+    const linkId = convertLibraryNameToLinkId(
+      "contracts/protocol/integration/lib/Compound.sol:Compound"
+    );
 
     return await new CompoundLeverageModule__factory(
       // @ts-ignore


### PR DESCRIPTION
A fix to make it possible to import from `utils/common` in a Hardhat task without triggering the dreaded `HH9`

```
Error HH9: Error while loading Hardhat's configuration.
You probably imported hardhat instead of hardhat/config
```