### PR TITLE
Add Manager permissions for protected modules and extensions

### DIFF
--- a/contracts/adapters/FeeSplitAdapter.sol
+++ b/contracts/adapters/FeeSplitAdapter.sol
@@ -100,8 +100,9 @@ contract FeeSplitAdapter is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
     }
 
     /**
-     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. NOTE: This will accrue streaming fees though not send to operator
-     * and methodologist.
+     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. Fees are distributed to ensure
+     * that the accrual triggered in the StreamingFeeModule doesn't stay with the BaseManager
+     * where it might be poached by another extension.
      */
     function updateStreamingFee(uint256 _newFee)
         external
@@ -110,6 +111,7 @@ contract FeeSplitAdapter is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
     {
         bytes memory callData = abi.encodeWithSignature("updateStreamingFee(address,uint256)", manager.setToken(), _newFee);
         invokeManager(address(streamingFeeModule), callData);
+        accrueFeesAndDistribute();
     }
 
     /**

--- a/contracts/adapters/FeeSplitExtension.sol
+++ b/contracts/adapters/FeeSplitExtension.sol
@@ -111,8 +111,11 @@ contract FeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpgrade {
     }
 
     /**
-     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. NOTE: This will accrue streaming
-     * fees though not send to operator fee recipient and methodologist.
+     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. Operator and Methodologist must each call
+     * this function to execute the update. Because the method is timelocked, each party must call it twice:
+     * once to set the lock and once to execute.
+     *
+     * NOTE: This will accrue streaming fees though not send to operator fee recipient and methodologist.
      */
     function updateStreamingFee(uint256 _newFee)
         external
@@ -125,6 +128,8 @@ contract FeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpgrade {
 
     /**
      * MUTUAL UPGRADE: Updates issue fee on IssuanceModule. Only is executed once time lock has passed.
+     * Operator and Methodologist must each call this function to execute the update. Because the method
+     * is timelocked, each party must call it twice: once to set the lock and once to execute.
      */
     function updateIssueFee(uint256 _newFee)
         external
@@ -137,6 +142,8 @@ contract FeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpgrade {
 
     /**
      * MUTUAL UPGRADE: Updates redeem fee on IssuanceModule. Only is executed once time lock has passed.
+     * Operator and Methodologist must each call this function to execute the update. Because the method is
+     * timelocked, each party must call it twice: once to set the lock and once to execute.
      */
     function updateRedeemFee(uint256 _newFee)
         external

--- a/contracts/adapters/FeeSplitExtension.sol
+++ b/contracts/adapters/FeeSplitExtension.sol
@@ -19,7 +19,7 @@ pragma solidity 0.6.10;
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
-import { BaseAdapter } from "../lib/BaseAdapter.sol";
+import { BaseExtension } from "../lib/BaseExtension.sol";
 import { IIssuanceModule } from "../interfaces/IIssuanceModule.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
@@ -35,7 +35,7 @@ import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
  *
  * Smart contract extension that allows for splitting and setting streaming and mint/redeem fees.
  */
-contract FeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
+contract FeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpgrade {
     using Address for address;
     using PreciseUnitMath for uint256;
     using SafeMath for uint256;
@@ -71,7 +71,7 @@ contract FeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
         address _operatorFeeRecipient
     )
         public
-        BaseAdapter(_manager)
+        BaseExtension(_manager)
     {
         streamingFeeModule = _streamingFeeModule;
         issuanceModule = _issuanceModule;

--- a/contracts/adapters/FeeSplitExtension.sol
+++ b/contracts/adapters/FeeSplitExtension.sol
@@ -30,12 +30,12 @@ import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
 
 
 /**
- * @title FeeSplitAdapter
+ * @title FeeSplitExtension
  * @author Set Protocol
  *
- * Smart contract adapter that allows for splitting and setting streaming and mint/redeem fees.
+ * Smart contract extension that allows for splitting and setting streaming and mint/redeem fees.
  */
-contract FeeSplitAdapter is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
+contract FeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
     using Address for address;
     using PreciseUnitMath for uint256;
     using SafeMath for uint256;

--- a/contracts/adapters/FeeSplitExtension.sol
+++ b/contracts/adapters/FeeSplitExtension.sol
@@ -84,9 +84,9 @@ contract FeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpgrade {
 
     /**
      * ANYONE CALLABLE: Accrues fees from streaming fee module. Gets resulting balance after fee accrual, calculates fees for
-     * operator and methodologist, and sends to operator and methodologist, and sends to operatorFeeRecipient and methodlogist
-     * respectively. NOTE: mint/redeem fees will automatically be sent to this address so reading the balance of the SetToken
-     * in the contract after accrual is sufficient for accounting for all collected fees.
+     * operator and methodologist, and sends to operator fee recipient and methodologist respectively. NOTE: mint/redeem fees
+     * will automatically be sent to this address so reading the balance of the SetToken in the contract after accrual is
+     * sufficient for accounting for all collected fees.
      */
     function accrueFeesAndDistribute() public {
         // Emits a FeeActualized event

--- a/contracts/adapters/GIMExtension.sol
+++ b/contracts/adapters/GIMExtension.sol
@@ -21,7 +21,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
 import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
-import { BaseAdapter } from "../lib/BaseAdapter.sol";
+import { BaseExtension } from "../lib/BaseExtension.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
 import { IGeneralIndexModule } from "../interfaces/IGeneralIndexModule.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
@@ -32,21 +32,21 @@ import { ISetToken } from "../interfaces/ISetToken.sol";
  *
  * Smart contract manager extension that acts as a pass-through contract for interacting with GeneralIndexModule.
  * All functions are only callable by operator. startRebalance() on GIM maps to startRebalanceWithUnits on
- * GIMExtension. 
+ * GIMExtension.
  */
-contract GIMExtension is BaseAdapter {
+contract GIMExtension is BaseExtension {
 
     using AddressArrayUtils for address[];
     using SafeMath for uint256;
 
     /* ============ State Variables ============ */
-    
+
     ISetToken public setToken;
     IGeneralIndexModule public generalIndexModule;  // GIM
 
     /* ============ Constructor ============ */
 
-    constructor(IBaseManager _manager, IGeneralIndexModule _generalIndexModule) public BaseAdapter(_manager) {
+    constructor(IBaseManager _manager, IGeneralIndexModule _generalIndexModule) public BaseExtension(_manager) {
         generalIndexModule = _generalIndexModule;
         setToken = manager.setToken();
     }
@@ -97,7 +97,7 @@ contract GIMExtension is BaseAdapter {
             _tradeMaximums
         );
 
-        invokeManager(address(generalIndexModule), callData);   
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -120,7 +120,7 @@ contract GIMExtension is BaseAdapter {
             _exchangeNames
         );
 
-        invokeManager(address(generalIndexModule), callData);  
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -143,7 +143,7 @@ contract GIMExtension is BaseAdapter {
             _coolOffPeriods
         );
 
-        invokeManager(address(generalIndexModule), callData);  
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -166,7 +166,7 @@ contract GIMExtension is BaseAdapter {
             _exchangeData
         );
 
-        invokeManager(address(generalIndexModule), callData); 
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -181,7 +181,7 @@ contract GIMExtension is BaseAdapter {
             _raiseTargetPercentage
         );
 
-        invokeManager(address(generalIndexModule), callData); 
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -204,7 +204,7 @@ contract GIMExtension is BaseAdapter {
             _statuses
         );
 
-        invokeManager(address(generalIndexModule), callData); 
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -219,7 +219,7 @@ contract GIMExtension is BaseAdapter {
             _status
         );
 
-        invokeManager(address(generalIndexModule), callData); 
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /**
@@ -231,7 +231,7 @@ contract GIMExtension is BaseAdapter {
             setToken
         );
 
-        invokeManager(address(generalIndexModule), callData);    
+        invokeManager(address(generalIndexModule), callData);
     }
 
     /* ============ Internal Functions ============ */

--- a/contracts/adapters/GovernanceExtension.sol
+++ b/contracts/adapters/GovernanceExtension.sol
@@ -16,30 +16,30 @@
 
 pragma solidity 0.6.10;
 
-import { BaseAdapter } from "../lib/BaseAdapter.sol";
+import { BaseExtension } from "../lib/BaseExtension.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
 import { IGovernanceModule } from "../interfaces/IGovernanceModule.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 
 /**
- * @title GovernanceAdapter
+ * @title GovernanceExtension
  * @author Set Protocol
  *
- * Smart contract adapter that acts as a manager interface for interacting with the Set Protocol
+ * Smart contract extension that acts as a manager interface for interacting with the Set Protocol
  * GovernanceModule to perform meta-governance actions. All governance functions are callable only
  * by a subset of allowed callers. The operator has the power to add/remove callers from the allowed
  * callers mapping.
  */
-contract GovernanceAdapter is BaseAdapter {
+contract GovernanceExtension is BaseExtension {
 
     /* ============ State Variables ============ */
-    
+
     ISetToken public setToken;
     IGovernanceModule public governanceModule;
-    
+
     /* ============ Constructor ============ */
 
-    constructor(IBaseManager _manager, IGovernanceModule _governanceModule) public BaseAdapter(_manager) {
+    constructor(IBaseManager _manager, IGovernanceModule _governanceModule) public BaseExtension(_manager) {
         governanceModule = _governanceModule;
         setToken = manager.setToken();
     }
@@ -48,9 +48,9 @@ contract GovernanceAdapter is BaseAdapter {
 
     /**
      * ONLY APPROVED CALLER: Submits a delegate call to the GovernanceModule. Approved caller mapping
-     * is part of BaseAdapter.
+     * is part of BaseExtension.
      *
-     * @param _governanceName       Name of governance adapter being used
+     * @param _governanceName       Name of governance extension being used
      */
     function delegate(
         string memory _governanceName,
@@ -71,9 +71,9 @@ contract GovernanceAdapter is BaseAdapter {
 
     /**
      * ONLY APPROVED CALLER: Submits a proposal call to the GovernanceModule. Approved caller mapping
-     * is part of BaseAdapter.
+     * is part of BaseExtension.
      *
-     * @param _governanceName       Name of governance adapter being used
+     * @param _governanceName       Name of governance extension being used
      * @param _proposalData         Byte data of proposal
      */
     function propose(
@@ -95,9 +95,9 @@ contract GovernanceAdapter is BaseAdapter {
 
     /**
      * ONLY APPROVED CALLER: Submits a register call to the GovernanceModule. Approved caller mapping
-     * is part of BaseAdapter.
+     * is part of BaseExtension.
      *
-     * @param _governanceName       Name of governance adapter being used
+     * @param _governanceName       Name of governance extension being used
      */
     function register(string memory _governanceName) external onlyAllowedCaller(msg.sender) {
         bytes memory callData = abi.encodeWithSelector(
@@ -111,9 +111,9 @@ contract GovernanceAdapter is BaseAdapter {
 
     /**
      * ONLY APPROVED CALLER: Submits a revoke call to the GovernanceModule. Approved caller mapping
-     * is part of BaseAdapter.
+     * is part of BaseExtension.
      *
-     * @param _governanceName       Name of governance adapter being used
+     * @param _governanceName       Name of governance extension being used
      */
     function revoke(string memory _governanceName) external onlyAllowedCaller(msg.sender) {
         bytes memory callData = abi.encodeWithSelector(
@@ -127,9 +127,9 @@ contract GovernanceAdapter is BaseAdapter {
 
     /**
      * ONLY APPROVED CALLER: Submits a vote call to the GovernanceModule. Approved caller mapping
-     * is part of BaseAdapter.
+     * is part of BaseExtension.
      *
-     * @param _governanceName       Name of governance adapter being used
+     * @param _governanceName       Name of governance extension being used
      * @param _proposalId           Id of proposal being voted on
      * @param _support              Boolean indicating if supporting proposal
      * @param _data                 Arbitrary bytes to be used to construct vote call data

--- a/contracts/adapters/StreamingFeeSplitExtension.sol
+++ b/contracts/adapters/StreamingFeeSplitExtension.sol
@@ -96,8 +96,9 @@ contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgra
     }
 
     /**
-     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. NOTE: This will accrue streaming fees to the manager contract
-     * but not distribute to the operator and methodologist.
+     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. Fees are distributed to ensure
+     * that the accrual triggered in the StreamingFeeModule doesn't stay with the BaseManager
+     * where it might be poached by another extension.
      */
     function updateStreamingFee(uint256 _newFee)
         external
@@ -111,6 +112,7 @@ contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgra
         );
 
         invokeManager(address(streamingFeeModule), callData);
+        accrueFeesAndDistribute();
     }
 
     /**

--- a/contracts/adapters/StreamingFeeSplitExtension.sol
+++ b/contracts/adapters/StreamingFeeSplitExtension.sol
@@ -107,8 +107,11 @@ contract StreamingFeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpg
     }
 
     /**
-     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. NOTE: This will accrue streaming
-     * fees though not send to operator fee recipient and methodologist.
+     * MUTUAL UPGRADE: Updates streaming fee on StreamingFeeModule. Operator and Methodologist must
+     * each call this function to execute the update. Because the method is timelocked, each party
+     * must call it twice: once to set the lock and once to execute.
+     *
+     * NOTE: This will accrue streaming fees though not send to operator fee recipient and methodologist.
      */
     function updateStreamingFee(uint256 _newFee)
         external

--- a/contracts/adapters/StreamingFeeSplitExtension.sol
+++ b/contracts/adapters/StreamingFeeSplitExtension.sol
@@ -19,7 +19,7 @@ pragma solidity 0.6.10;
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
-import { BaseAdapter } from "../lib/BaseAdapter.sol";
+import { BaseExtension } from "../lib/BaseExtension.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 import { IStreamingFeeModule } from "../interfaces/IStreamingFeeModule.sol";
@@ -35,7 +35,7 @@ import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
  * Smart contract manager extension that allows for splitting and setting streaming fees. Fee splits are updated by operator.
  * Any fee updates are timelocked.
  */
-contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgrade {
+contract StreamingFeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpgrade {
     using Address for address;
     using PreciseUnitMath for uint256;
     using SafeMath for uint256;
@@ -69,7 +69,7 @@ contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgra
         address _operatorFeeRecipient
     )
         public
-        BaseAdapter(_manager)
+        BaseExtension(_manager)
     {
         streamingFeeModule = _streamingFeeModule;
         operatorFeeSplit = _operatorFeeSplit;

--- a/contracts/adapters/StreamingFeeSplitExtension.sol
+++ b/contracts/adapters/StreamingFeeSplitExtension.sol
@@ -15,6 +15,7 @@
 */
 
 pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
@@ -104,6 +105,26 @@ contract StreamingFeeSplitExtension is BaseExtension, TimeLockUpgrade, MutualUpg
         }
 
         emit FeesDistributed(operatorFeeRecipient, methodologist, operatorTake, methodologistTake);
+    }
+
+    /**
+     * MUTUAL UPGRADE: Initializes the streaming fee module. Operator and Methodologist must each call
+     * this function to execute the update.
+     *
+     * This method is called after invoking `replaceProtectedModule` or `emergencyReplaceProtectedModule`
+     * to configure the replacement streaming fee module's fee settings.
+     */
+    function initializeModule(IStreamingFeeModule.FeeState memory _settings)
+        external
+        mutualUpgrade(manager.operator(), manager.methodologist())
+    {
+        bytes memory callData = abi.encodeWithSelector(
+            IStreamingFeeModule.initialize.selector,
+            manager.setToken(),
+            _settings
+        );
+
+        invokeManager(address(streamingFeeModule), callData);
     }
 
     /**

--- a/contracts/adapters/StreamingFeeSplitExtension.sol
+++ b/contracts/adapters/StreamingFeeSplitExtension.sol
@@ -52,18 +52,23 @@ contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgra
     // Percent of fees in precise units (10^16 = 1%) sent to operator, rest to methodologist
     uint256 public operatorFeeSplit;
 
+    // Address which receives operator's share of fees when they're distributed. (See IIP-72)
+    address public operatorFeeRecipient;
+
     /* ============ Constructor ============ */
 
     constructor(
         IBaseManager _manager,
         IStreamingFeeModule _streamingFeeModule,
-        uint256 _operatorFeeSplit
+        uint256 _operatorFeeSplit,
+        address _operatorFeeRecipient
     )
         public
         BaseAdapter(_manager)
     {
         streamingFeeModule = _streamingFeeModule;
         operatorFeeSplit = _operatorFeeSplit;
+        operatorFeeRecipient = _operatorFeeRecipient;
         setToken = manager.setToken();
     }
 
@@ -71,28 +76,27 @@ contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgra
 
     /**
      * ANYONE CALLABLE: Accrues fees from streaming fee module. Gets resulting balance after fee accrual, calculates fees for
-     * operator and methodologist, and sends to each.
+     * operator and methodologist, and sends to operatorFeeRecipient and methodlogist respectively.
      */
     function accrueFeesAndDistribute() public {
         streamingFeeModule.accrueFee(setToken);
 
         uint256 totalFees = setToken.balanceOf(address(manager));
 
-        address operator = manager.operator();
         address methodologist = manager.methodologist();
 
         uint256 operatorTake = totalFees.preciseMul(operatorFeeSplit);
         uint256 methodologistTake = totalFees.sub(operatorTake);
 
         if (operatorTake > 0) {
-            invokeManagerTransfer(address(setToken), operator, operatorTake);
+            invokeManagerTransfer(address(setToken), operatorFeeRecipient, operatorTake);
         }
 
         if (methodologistTake > 0) {
             invokeManagerTransfer(address(setToken), methodologist, methodologistTake);
         }
 
-        emit FeesAccrued(operator, methodologist, operatorTake, methodologistTake);
+        emit FeesAccrued(operatorFeeRecipient, methodologist, operatorTake, methodologistTake);
     }
 
     /**
@@ -142,5 +146,16 @@ contract StreamingFeeSplitExtension is BaseAdapter, TimeLockUpgrade, MutualUpgra
         require(_newFeeSplit <= PreciseUnitMath.preciseUnit(), "Fee must be less than 100%");
         accrueFeesAndDistribute();
         operatorFeeSplit = _newFeeSplit;
+    }
+
+    /**
+     * OPERATOR ONLY: Updates the address that receives the operator's share of the fees (see IIP-72)
+     */
+    function updateOperatorFeeRecipient(address _newOperatorFeeRecipient)
+        external
+        onlyOperator
+    {
+        require(_newOperatorFeeRecipient != address(0), "Zero address not valid");
+        operatorFeeRecipient = _newOperatorFeeRecipient;
     }
 }

--- a/contracts/interfaces/IExtension.sol
+++ b/contracts/interfaces/IExtension.sol
@@ -1,0 +1,26 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+pragma experimental "ABIEncoderV2";
+
+import { IBaseManager } from "./IBaseManager.sol";
+
+interface IExtension {
+    function manager() external view returns (IBaseManager);
+}

--- a/contracts/interfaces/IIssuanceModule.sol
+++ b/contracts/interfaces/IIssuanceModule.sol
@@ -29,4 +29,13 @@ interface IIssuanceModule {
     function updateIssueFee(ISetToken _setToken, uint256 _newIssueFee) external;
     function updateRedeemFee(ISetToken _setToken, uint256 _newRedeemFee) external;
     function updateFeeRecipient(ISetToken _setToken, address _newRedeemFee) external;
+
+    function initialize(
+        ISetToken _setToken,
+        uint256 _maxManagerFee,
+        uint256 _managerIssueFee,
+        uint256 _managerRedeemFee,
+        address _feeRecipient,
+        address _managerIssuanceHook
+    ) external;
 }

--- a/contracts/interfaces/IStreamingFeeModule.sol
+++ b/contracts/interfaces/IStreamingFeeModule.sol
@@ -4,8 +4,16 @@ pragma experimental "ABIEncoderV2";
 import { ISetToken } from "./ISetToken.sol";
 
 interface IStreamingFeeModule {
+    struct FeeState {
+        address feeRecipient;
+        uint256 maxStreamingFeePercentage;
+        uint256 streamingFeePercentage;
+        uint256 lastStreamingFeeTimestamp;
+    }
+
     function getFee(ISetToken _setToken) external view returns (uint256);
     function accrueFee(ISetToken _setToken) external;
     function updateStreamingFee(ISetToken _setToken, uint256 _newFee) external;
     function updateFeeRecipient(ISetToken _setToken, address _newFeeRecipient) external;
+    function initialize(ISetToken _setToken, FeeState memory _settings) external;
 }

--- a/contracts/lib/BaseExtension.sol
+++ b/contracts/lib/BaseExtension.sol
@@ -20,12 +20,12 @@ import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
 
 /**
- * @title BaseAdapter
+ * @title BaseExtension
  * @author Set Protocol
  *
- * Abstract class that houses common adapter-related state and functions.
+ * Abstract class that houses common extension-related state and functions.
  */
-abstract contract BaseAdapter {
+abstract contract BaseExtension {
     using AddressArrayUtils for address[];
 
     /* ============ Events ============ */
@@ -104,7 +104,7 @@ abstract contract BaseAdapter {
     }
 
     /**
-     * OPERATOR ONLY: Toggle whether anyone can call function, bypassing the callAllowlist 
+     * OPERATOR ONLY: Toggle whether anyone can call function, bypassing the callAllowlist
      *
      * @param _status           Boolean indicating whether to allow anyone call
      */
@@ -114,7 +114,7 @@ abstract contract BaseAdapter {
     }
 
     /* ============ Internal Functions ============ */
-    
+
     /**
      * Invoke manager to transfer tokens from manager to other contract.
      *

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -160,7 +160,8 @@ contract BaseManager is MutualUpgrade {
 
     // Counter incremented when the operator "emergency removes" a protected module. Decremented
     // when methodologist executes an "emergency replacement". Operator can only add modules and
-    // adapters when `emergencies` is zero.
+    // adapters when `emergencies` is zero. Emergencies can only be declared "over" by mutual agreement
+    // between operator and methodologist OR by the methodologist alone via `resolveEmergency`
     uint256 public emergencies;
 
     // Mapping of protected modules. These cannot be called or removed except by mutual upgrade.

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -248,7 +248,7 @@ contract BaseManager is MutualUpgrade {
 
     /**
      * MUTUAL UPGRADE: Authorizes an adapter for a protected module. Operator and Methodologist must
-     * each call this function to execute the update.
+     * each call this function to execute the update. Adds adapter to manager if not already present.
      *
      * @param _module           Module to authorize adapter for
      * @param _adapter          Adapter to authorize for module
@@ -258,8 +258,11 @@ contract BaseManager is MutualUpgrade {
         mutualUpgrade(operator, methodologist)
     {
         require(protectedModules[_module].isProtected, "Module not protected");
-        require(isAdapter[_adapter], "Adapter does not exist");
         require(!protectedModules[_module].authorizedAdapters[_adapter], "Adapter already authorized");
+
+        if (!isAdapter[_adapter]) {
+            _addAdapter(_adapter);
+        }
 
         protectedModules[_module].authorizedAdapters[_adapter] = true;
         protectedModules[_module].authorizedAdaptersList.push(_adapter);

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -346,7 +346,7 @@ contract BaseManager is MutualUpgrade {
         upgradesPermitted
         onlyOperator
     {
-        require(setToken.isInitializedModule(_module), "Module not valid");
+        require(setToken.isInitializedModule(_module), "Module not added yet");
         _protectModule(_module, _adapters);
 
         emit ModuleProtected(_module, _adapters);

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -15,14 +15,12 @@
 */
 
 pragma solidity 0.6.10;
-pragma experimental ABIEncoderV2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
 import { IAdapter } from "../interfaces/IAdapter.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
-import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
 
 
 /**
@@ -31,17 +29,9 @@ import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
  *
  * Smart contract manager that contains permissions and admin functionality
  */
-contract BaseManager is MutualUpgrade {
+contract BaseManager {
     using Address for address;
     using AddressArrayUtils for address[];
-
-    /* ============ Struct ========== */
-
-    struct ProtectedModule {
-        bool isProtected;                               // Flag set to true if module is protected
-        address[] authorizedAdaptersList;               // List of Adapters authorized to call module
-        mapping(address => bool) authorizedAdapters;    // Map of adapters authorized to call module
-    }
 
     /* ============ Events ============ */
 
@@ -61,40 +51,6 @@ contract BaseManager is MutualUpgrade {
     event OperatorChanged(
         address _oldOperator,
         address _newOperator
-    );
-
-    event AdapterAuthorized(
-        address _module,
-        address _adapter
-    );
-
-    event AdapterAuthorizationRevoked(
-        address _module,
-        address _adapter
-    );
-
-    event ModuleProtected(
-        address _module,
-        address[] _adapters
-    );
-
-    event ModuleUnprotected(
-        address _module
-    );
-
-    event ReplacedProtectedModule(
-        address _oldModule,
-        address _newModule,
-        address[] _newAdapters
-    );
-
-    event EmergencyReplacedProtectedModule(
-        address _module,
-        address[] _adapters
-    );
-
-    event EmergencyRemovedProtectedModule(
-        address _module
     );
 
     /* ============ Modifiers ============ */
@@ -123,24 +79,6 @@ contract BaseManager is MutualUpgrade {
         _;
     }
 
-    /**
-     * Throws if contract is in an emergency state following a unilateral operator removal of a
-     * protected module.
-     */
-    modifier upgradesPermitted() {
-        require(emergencies == 0, "Upgrades paused by emergency");
-        _;
-    }
-
-    /**
-     * Throws if contract is *not* in an emergency state. Emergency replacement and resolution
-     * can only happen in an emergency
-     */
-    modifier onlyEmergency() {
-        require(emergencies > 0, "Not in emergency");
-        _;
-    }
-
     /* ============ State Variables ============ */
 
     // Instance of SetToken
@@ -158,54 +96,21 @@ contract BaseManager is MutualUpgrade {
     // Address of methodologist which serves as providing methodology for the index
     address public methodologist;
 
-    // Counter incremented when the operator "emergency removes" a protected module. Decremented
-    // when methodologist executes an "emergency replacement". Operator can only add modules and
-    // adapters when `emergencies` is zero. Emergencies can only be declared "over" by mutual agreement
-    // between operator and methodologist or by the methodologist alone via `resolveEmergency`
-    uint256 public emergencies;
-
-    // Mapping of protected modules. These cannot be called or removed except by mutual upgrade.
-    mapping(address => ProtectedModule) public protectedModules;
-
-    // List of protected modules, for iteration. Used when checking that an adapter removal
-    // can happen without methodologist approval
-    address[] public protectedModulesList;
-
-    // Boolean set when methodologist authorizes initialization after contract deployment.
-    // Must be true to call via `interactManager`.
-    bool public initialized;
-
     /* ============ Constructor ============ */
 
     constructor(
         ISetToken _setToken,
         address _operator,
-        address _methodologist,
-        address[] memory _protectedModules,      // Modules to initialize as protected
-        address[][] memory _authorizedAdapters   // Adapters authorized for each protected module
+        address _methodologist
     )
         public
     {
         setToken = _setToken;
         operator = _operator;
         methodologist = _methodologist;
-
-        for (uint256 i = 0; i < _protectedModules.length; i++) {
-            _protectModule(_protectedModules[i], _authorizedAdapters[i]);
-        }
     }
 
     /* ============ External Functions ============ */
-
-    /**
-     * ONLY METHODOLOGIST : Called by the methodologist to enable contract. All `interactManager`
-     * calls revert until this is invoked. Lets methodologist review and authorize initial protected
-     * module settings.
-     */
-    function authorizeInitialization() external onlyMethodologist {
-        require(!initialized, "Initialization authorized");
-        initialized = true;
-    }
 
     /**
      * MUTUAL UPGRADE: Update the SetToken manager address. Operator and Methodologist must each call
@@ -213,31 +118,34 @@ contract BaseManager is MutualUpgrade {
      *
      * @param _newManager           New manager address
      */
-    function setManager(address _newManager) external mutualUpgrade(operator, methodologist) {
+    function setManager(address _newManager) external onlyOperator {
         require(_newManager != address(0), "Zero address not valid");
         setToken.setManager(_newManager);
     }
 
     /**
-     * OPERATOR ONLY: Add a new adapter that the BaseManager can call.
+     * MUTUAL UPGRADE: Add a new adapter that the BaseManager can call.
      *
      * @param _adapter           New adapter to add
      */
-    function addAdapter(address _adapter) external upgradesPermitted onlyOperator {
+    function addAdapter(address _adapter) external onlyOperator {
         require(!isAdapter[_adapter], "Adapter already exists");
         require(address(IAdapter(_adapter).manager()) == address(this), "Adapter manager invalid");
 
-        _addAdapter(_adapter);
+        adapters.push(_adapter);
+
+        isAdapter[_adapter] = true;
+
+        emit AdapterAdded(_adapter);
     }
 
     /**
-     * OPERATOR ONLY: Remove an existing adapter tracked by the BaseManager.
+     * MUTUAL UPGRADE: Remove an existing adapter tracked by the BaseManager.
      *
      * @param _adapter           Old adapter to remove
      */
     function removeAdapter(address _adapter) external onlyOperator {
         require(isAdapter[_adapter], "Adapter does not exist");
-        require(!_isAuthorizedAdapter(_adapter), "Adapter used by protected module");
 
         adapters.removeStorage(_adapter);
 
@@ -247,63 +155,12 @@ contract BaseManager is MutualUpgrade {
     }
 
     /**
-     * MUTUAL UPGRADE: Authorizes an adapter for a protected module. Operator and Methodologist must
-     * each call this function to execute the update. Adds adapter to manager if not already present.
-     *
-     * @param _module           Module to authorize adapter for
-     * @param _adapter          Adapter to authorize for module
-     */
-    function authorizeAdapter(address _module, address _adapter)
-        external
-        mutualUpgrade(operator, methodologist)
-    {
-        require(protectedModules[_module].isProtected, "Module not protected");
-        require(!protectedModules[_module].authorizedAdapters[_adapter], "Adapter already authorized");
-
-        if (!isAdapter[_adapter]) {
-            _addAdapter(_adapter);
-        }
-
-        protectedModules[_module].authorizedAdapters[_adapter] = true;
-        protectedModules[_module].authorizedAdaptersList.push(_adapter);
-
-        emit AdapterAuthorized(_module, _adapter);
-    }
-
-    /**
-     * MUTUAL UPGRADE: Revokes adapter authorization for a protected module. Operator and Methodologist
-     * must each call this function to execute the update. In order to remove the extension completely
-     * from the contract removeAdapter must be called by the operator.
-     *
-     * @param _module           Module to revoke adapter authorization for
-     * @param _adapter          Adapter to revoke authorization of
-     */
-    function revokeAdapterAuthorization(address _module, address _adapter)
-        external
-        mutualUpgrade(operator, methodologist)
-    {
-        require(protectedModules[_module].isProtected, "Module not protected");
-        require(isAdapter[_adapter], "Adapter does not exist");
-        require(protectedModules[_module].authorizedAdapters[_adapter], "Adapter not authorized");
-
-        protectedModules[_module].authorizedAdapters[_adapter] = false;
-        protectedModules[_module].authorizedAdaptersList.removeStorage(_adapter);
-
-        emit AdapterAuthorizationRevoked(_module, _adapter);
-    }
-
-    /**
-     * ADAPTER ONLY: Interact with a module registered on the SetToken. Manager initialization must
-     * have been authorized by methodologist. Adapter making this call must be authorized
-     * to call module if module is protected.
+     * ADAPTER ONLY: Interact with a module registered on the SetToken.
      *
      * @param _module           Module to interact with
      * @param _data             Byte data of function to call in module
      */
-    function interactManager(address _module, bytes memory _data) external onlyAdapter {
-        require(initialized, "Manager not initialized");
-        require(_senderAuthorizedForModule(_module, msg.sender), "Adapter not authorized for module");
-
+    function interactManager(address _module, bytes calldata _data) external onlyAdapter {
         // Invoke call to module, assume value will always be 0
         _module.functionCallWithValue(_data, 0);
     }
@@ -313,164 +170,17 @@ contract BaseManager is MutualUpgrade {
      *
      * @param _module           New module to add
      */
-    function addModule(address _module) external upgradesPermitted onlyOperator {
+    function addModule(address _module) external onlyOperator {
         setToken.addModule(_module);
     }
 
     /**
-     * OPERATOR ONLY: Remove a new module from the SetToken. Any adapters associated with this
-     * module need to be removed in separate transactions via removeAdapter.
+     * OPERATOR ONLY: Remove a new module from the SetToken.
      *
      * @param _module           Module to remove
      */
     function removeModule(address _module) external onlyOperator {
-        require(!protectedModules[_module].isProtected, "Module protected");
         setToken.removeModule(_module);
-    }
-
-    /**
-     * OPERATOR ONLY: Marks a currently protected module as unprotected and deletes its authorized
-     * adapter registries. Removes module from the SetToken. Increments the `emergencies` counter,
-     * prohibiting any operator-only module or extension additions until `emergencyReplaceProtectedModule`
-     * is executed or `resolveEmergency` is called by the methodologist.
-     *
-     * Called by operator when a module must be removed immediately for security reasons and it's unsafe
-     * to wait for a `mutualUpgrade` process to play out.
-     *
-     * NOTE: If removing a fee module, you can ensure all fees are distributed by calling distribute
-     * on the module's de-authorized fee adapter after this call.
-     *
-     * @param _module           Module to remove
-     */
-    function emergencyRemoveProtectedModule(address _module) external onlyOperator {
-        _unProtectModule(_module);
-        setToken.removeModule(_module);
-        emergencies += 1;
-
-        EmergencyRemovedProtectedModule(_module);
-    }
-
-    /**
-     * OPERATOR ONLY: Marks an existing module as protected and authorizes existing adapters for
-     * it. Adds module to the protected modules list
-     *
-     * The operator uses this when they're adding new features and want to assure the methodologist
-     * they won't be unilaterally changed in the future. Cannot be called during an emergency because
-     * methodologist needs to explicitly approve protection arrangements under those conditions.
-     *
-     * NOTE: If adding a fee adapter while protecting a fee module, it's important to set the
-     * module `feeRecipient` to the new adapter's address (ideally before this call).
-     *
-     * @param  _module          Module to protect
-     * @param  _adapters        Array of adapters to authorize for protected module
-     */
-    function protectModule(address _module, address[] memory _adapters)
-        external
-        upgradesPermitted
-        onlyOperator
-    {
-        require(setToken.getModules().contains(_module), "Module not added yet");
-        _protectModule(_module, _adapters);
-
-        emit ModuleProtected(_module, _adapters);
-    }
-
-    /**
-     * METHODOLOGIST ONLY: Marks a currently protected module as unprotected and deletes its authorized
-     * adapter registries. Removes old module from the protected modules list.
-     *
-     * Called by the methodologist when they want to cede control over a protected module without triggering
-     * an emergency (for example, to remove it because its dead).
-     *
-     * @param  _module          Module to revoke protections for
-     */
-    function unProtectModule(address _module) external onlyMethodologist {
-        _unProtectModule(_module);
-
-        emit ModuleUnprotected(_module);
-    }
-
-    /**
-     * MUTUAL UPGRADE: Replaces a protected module. Operator and Methodologist must each call this
-     * function to execute the update.
-     *
-     * > Marks a currently protected module as unprotected
-     * > Deletes its authorized adapter registries.
-     * > Removes old module from SetToken.
-     * > Adds new module to SetToken.
-     * > Marks `_newModule` as protected and authorizes new adapters for it.
-     *
-     * Used when methodologists wants to guarantee that an existing protection arrangement is replaced
-     * with a suitable substitute (ex: upgrading a StreamingFeeSplitExtension).
-     *
-     * NOTE: If replacing a fee module, it's necessary to set the module `feeRecipient` to be
-     * the new fee adapter address after this call. Any fees remaining in the old module's
-     * de-authorized adapters can be distributed by calling `distribute()` on the old adapter.
-     *
-     * @param _oldModule        Module to remove
-     * @param _newModule        Module to add in place of removed module
-     * @param _newAdapters      Adapters to authorize for new module
-     */
-    function replaceProtectedModule(address _oldModule, address _newModule, address[] memory _newAdapters)
-        external
-        mutualUpgrade(operator, methodologist)
-    {
-        _unProtectModule(_oldModule);
-
-        setToken.removeModule(_oldModule);
-        setToken.addModule(_newModule);
-
-        _protectModule(_newModule, _newAdapters);
-
-        ReplacedProtectedModule(_oldModule, _newModule, _newAdapters);
-    }
-
-    /**
-     * MUTUAL UPGRADE & EMERGENCY ONLY: Replaces a module the operator has removed with
-     * `emergencyRemoveProtectedModule`. Operator and Methodologist must each call this function to
-     *  execute the update.
-     *
-     * > Adds new module to SetToken.
-     * > Marks `_newModule` as protected and authorizes new adapters for it.
-     * > Adds `_newModule` to protectedModules list.
-     * > Decrements the emergencies counter,
-     *
-     * Used when methodologist wants to guarantee that a protection arrangement which was
-     * removed in an emergency is replaced with a suitable substitute. Operator's ability to add modules
-     * or adapters is restored after invoking this method (if this is the only emergency.)
-     *
-     * NOTE: If replacing a fee module, it's necessary to set the module `feeRecipient` to be
-     * the new fee adapter address after this call. Any fees remaining in the old module's
-     * de-authorized adapters can be distributed by calling `distribute()` on the old adapter.
-     *
-     * @param _module        Module to add in place of removed module
-     * @param _adapters      Array of adapters to authorize for replacement module
-     */
-    function emergencyReplaceProtectedModule(
-        address _module,
-        address[] memory _adapters
-    )
-        external
-        mutualUpgrade(operator, methodologist)
-        onlyEmergency
-    {
-        setToken.addModule(_module);
-        _protectModule(_module, _adapters);
-
-        emergencies -= 1;
-
-        EmergencyReplacedProtectedModule(_module, _adapters);
-    }
-
-    /**
-     * METHODOLOGIST ONLY & EMERGENCY ONLY: Decrements the emergencies counter.
-     *
-     * Allows a methodologist to exit a state of emergency without replacing a protected module that
-     * was removed. This could happen if the module has no viable substitute or operator and methodologist
-     * agree that restoring normal operations is the best way forward.
-     */
-    function resolveEmergency() external onlyMethodologist onlyEmergency {
-        emergencies -= 1;
     }
 
     /**
@@ -499,94 +209,5 @@ contract BaseManager is MutualUpgrade {
 
     function getAdapters() external view returns(address[] memory) {
         return adapters;
-    }
-
-    function getAuthorizedAdapters(address _module) external view returns (address[] memory) {
-        return protectedModules[_module].authorizedAdaptersList;
-    }
-
-    function isAuthorizedAdapter(address _module, address _adapter) external view returns (bool) {
-        return protectedModules[_module].authorizedAdapters[_adapter];
-    }
-
-    function getProtectedModules() external view returns (address[] memory) {
-        return protectedModulesList;
-    }
-
-    /* ============ Internal ============ */
-
-
-    /**
-     * Add a new adapter that the BaseManager can call.
-     */
-    function _addAdapter(address _adapter) internal {
-        adapters.push(_adapter);
-
-        isAdapter[_adapter] = true;
-
-        emit AdapterAdded(_adapter);
-    }
-
-    /**
-     * Marks a currently protected module as unprotected and deletes it from authorized adapter
-     * registries. Removes module from the SetToken.
-     */
-    function _unProtectModule(address _module) internal {
-        require(protectedModules[_module].isProtected, "Module not protected");
-
-        // Clear mapping and array entries in struct before deleting mapping entry
-        for (uint256 i = 0; i < protectedModules[_module].authorizedAdaptersList.length; i++) {
-            address adapter = protectedModules[_module].authorizedAdaptersList[i];
-            protectedModules[_module].authorizedAdapters[adapter] = false;
-        }
-
-        delete protectedModules[_module];
-
-        protectedModulesList.removeStorage(_module);
-    }
-
-    /**
-     * Adds new module to SetToken. Marks `_newModule` as protected and authorizes
-     * new adapters for it. Adds `_newModule` module to protectedModules list.
-     */
-    function _protectModule(address _module, address[] memory _adapters) internal {
-        require(!protectedModules[_module].isProtected, "Module already protected");
-
-        protectedModules[_module].isProtected = true;
-        protectedModulesList.push(_module);
-
-        for (uint i = 0; i < _adapters.length; i++) {
-            if (!isAdapter[_adapters[i]]) {
-                _addAdapter(_adapters[i]);
-            }
-            protectedModules[_module].authorizedAdapters[_adapters[i]] = true;
-            protectedModules[_module].authorizedAdaptersList.push(_adapters[i]);
-        }
-    }
-
-    /**
-     * Searches the adapter mappings of each protected modules to determine if an extension
-     * is authorized by any of them. Authorized extensions cannot be unilaterally removed by
-     * the operator.
-     */
-    function _isAuthorizedAdapter(address _adapter) internal view returns (bool) {
-        for (uint256 i = 0; i < protectedModulesList.length; i++) {
-            if (protectedModules[protectedModulesList[i]].authorizedAdapters[_adapter]) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks if `_sender` (an adapter) is allowed to call a module (which may be protected)
-     */
-    function _senderAuthorizedForModule(address _module, address _sender) internal view returns (bool) {
-        if (protectedModules[_module].isProtected) {
-            return protectedModules[_module].authorizedAdapters[_sender];
-        }
-
-        return true;
     }
 }

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -161,7 +161,7 @@ contract BaseManager is MutualUpgrade {
     // Counter incremented when the operator "emergency removes" a protected module. Decremented
     // when methodologist executes an "emergency replacement". Operator can only add modules and
     // adapters when `emergencies` is zero. Emergencies can only be declared "over" by mutual agreement
-    // between operator and methodologist OR by the methodologist alone via `resolveEmergency`
+    // between operator and methodologist or by the methodologist alone via `resolveEmergency`
     uint256 public emergencies;
 
     // Mapping of protected modules. These cannot be called or removed except by mutual upgrade.
@@ -203,6 +203,7 @@ contract BaseManager is MutualUpgrade {
      * module settings.
      */
     function authorizeInitialization() external onlyMethodologist {
+        require(!initialized, "Initialization authorized");
         initialized = true;
     }
 

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -337,6 +337,9 @@ contract BaseManager is MutualUpgrade {
      * Called by operator when a module must be removed immediately for security reasons and it's unsafe
      * to wait for a `mutualUpgrade` process to play out.
      *
+     * NOTE: If removing a fee module, you can ensure all fees are distributed by calling distribute
+     * on the module's de-authorized fee adapter after this call.
+     *
      * @param _module           Module to remove
      */
     function emergencyRemoveProtectedModule(address _module) external onlyOperator {
@@ -354,6 +357,9 @@ contract BaseManager is MutualUpgrade {
      * The operator uses this when they're adding new features and want to assure the methodologist
      * they won't be unilaterally changed in the future. Cannot be called during an emergency because
      * methodologist needs to explicitly approve protection arrangements under those conditions.
+     *
+     * NOTE: If adding a fee adapter while protecting a fee module, it's important to set the
+     * module `feeRecipient` to the new adapter's address (ideally before this call).
      *
      * @param  _module          Module to protect
      * @param  _adapters        Array of adapters to authorize for protected module
@@ -397,6 +403,10 @@ contract BaseManager is MutualUpgrade {
      * Used when methodologists wants to guarantee that an existing protection arrangement is replaced
      * with a suitable substitute (ex: upgrading a StreamingFeeSplitExtension).
      *
+     * NOTE: If replacing a fee module, it's necessary to set the module `feeRecipient` to be
+     * the new fee adapter address after this call. Any fees remaining in the old module's
+     * de-authorized adapters can be distributed by calling `distribute()` on the old adapter.
+     *
      * @param _oldModule        Module to remove
      * @param _newModule        Module to add in place of removed module
      * @param _newAdapters      Adapters to authorize for new module
@@ -428,6 +438,10 @@ contract BaseManager is MutualUpgrade {
      * Used when methodologist wants to guarantee that a protection arrangement which was
      * removed in an emergency is replaced with a suitable substitute. Operator's ability to add modules
      * or adapters is restored after invoking this method (if this is the only emergency.)
+     *
+     * NOTE: If replacing a fee module, it's necessary to set the module `feeRecipient` to be
+     * the new fee adapter address after this call. Any fees remaining in the old module's
+     * de-authorized adapters can be distributed by calling `distribute()` on the old adapter.
      *
      * @param _module        Module to add in place of removed module
      * @param _adapters      Array of adapters to authorize for replacement module

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -15,12 +15,15 @@
 */
 
 pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/Initializable.sol";
 
 import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
 import { IAdapter } from "../interfaces/IAdapter.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
+import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
 
 
 /**
@@ -29,9 +32,17 @@ import { ISetToken } from "../interfaces/ISetToken.sol";
  *
  * Smart contract manager that contains permissions and admin functionality
  */
-contract BaseManager {
+contract BaseManager is Initializable, MutualUpgrade {
     using Address for address;
     using AddressArrayUtils for address[];
+
+    /* ============ Struct ========== */
+
+    struct ProtectedModule {
+        bool isProtected;                               // Flag set to true if module is protected
+        address[] authorizedAdaptersList;               // List of Adapters authorized to call module
+        mapping(address => bool) authorizedAdapters;    // Map of adapters authorized to call module
+    }
 
     /* ============ Events ============ */
 
@@ -79,6 +90,15 @@ contract BaseManager {
         _;
     }
 
+    /**
+      Throws if contract is in an emergency state following a unilateral operator removal of a
+      protected module.
+     */
+    modifier upgradesPermitted() {
+        require(emergencies == 0, "Upgrades paused by emergency");
+        _;
+    }
+
     /* ============ State Variables ============ */
 
     // Instance of SetToken
@@ -96,21 +116,46 @@ contract BaseManager {
     // Address of methodologist which serves as providing methodology for the index
     address public methodologist;
 
+    // Counter incremented when the operator "emergency removes" a protected module. Decremented
+    // when methodologist executes an "emergency replacement". Operator is only allowed to unilaterally
+    // add modules and extension when `emergencies` equals 0
+    uint256 public emergencies;
+
+    // Mapping of protected modules. These cannot be called or removed except by mutual upgrade.
+    mapping(address => ProtectedModule) public protectedModules;
+
+    // Allows iteration over the set of protected modules. Used when verifying that an adapter
+    // removal does not require methodologist consent
+    address[] public protectedModulesList;
+
     /* ============ Constructor ============ */
 
     constructor(
         ISetToken _setToken,
         address _operator,
-        address _methodologist
+        address _methodologist,
+        address[] memory _protectedModules,      // Modules to initialize as protected
+        address[][] memory _authorizedAdapters   // Adapters authorized for each protected module
     )
         public
     {
         setToken = _setToken;
         operator = _operator;
         methodologist = _methodologist;
+
+        for (uint256 i = 0; i < _protectedModules.length; i++) {
+            _addProtectedModule(_protectedModules[i], _authorizedAdapters[i]);
+        }
     }
 
     /* ============ External Functions ============ */
+
+    /**
+     * ONLY METHODOLOGIST : Called by the methodologist to enable contract. All `interactManager`
+     * calls revert until this is invoked. Lets methodologist review and authorize initial protected
+     * module settings.
+     */
+    function authorizeInitialization() external initializer onlyMethodologist {}
 
     /**
      * MUTUAL UPGRADE: Update the SetToken manager address. Operator and Methodologist must each call
@@ -124,28 +169,25 @@ contract BaseManager {
     }
 
     /**
-     * MUTUAL UPGRADE: Add a new adapter that the BaseManager can call.
+     * OPERATOR ONLY: Add a new adapter that the BaseManager can call.
      *
      * @param _adapter           New adapter to add
      */
-    function addAdapter(address _adapter) external onlyOperator {
+    function addAdapter(address _adapter) external upgradesPermitted onlyOperator {
         require(!isAdapter[_adapter], "Adapter already exists");
         require(address(IAdapter(_adapter).manager()) == address(this), "Adapter manager invalid");
 
-        adapters.push(_adapter);
-
-        isAdapter[_adapter] = true;
-
-        emit AdapterAdded(_adapter);
+        _addAdapter(_adapter);
     }
 
     /**
-     * MUTUAL UPGRADE: Remove an existing adapter tracked by the BaseManager.
+     * OPERATOR ONLY: Remove an existing adapter tracked by the BaseManager.
      *
      * @param _adapter           Old adapter to remove
      */
     function removeAdapter(address _adapter) external onlyOperator {
         require(isAdapter[_adapter], "Adapter does not exist");
+        require(!_isAuthorizedAdapter(_adapter), "Adapter used by protected module");
 
         adapters.removeStorage(_adapter);
 
@@ -155,12 +197,47 @@ contract BaseManager {
     }
 
     /**
-     * ADAPTER ONLY: Interact with a module registered on the SetToken.
+     * MUTUAL UPGRADE**: Authorizes an adapter for a protected module
+     */
+    function authorizeAdapter(address _module, address _adapter)
+        external
+        mutualUpgrade(operator, methodologist)
+    {
+        require(protectedModules[_module].isProtected, "Module not protected");
+        require(isAdapter[_adapter], "Adapter does not exist");
+        require(!protectedModules[_module].authorizedAdapters[_adapter], "Adapter already authorized");
+
+        protectedModules[_module].authorizedAdapters[_adapter] = true;
+        protectedModules[_module].authorizedAdaptersList.push(_adapter);
+    }
+
+    /**
+     * MUTUAL UPGRADE**: Revokes adapter authorization for a protected module
+     */
+    function revokeAdapterAuthorization(address _module, address _adapter)
+        external
+        mutualUpgrade(operator, methodologist)
+    {
+        require(protectedModules[_module].isProtected, "Module not protected");
+        require(isAdapter[_adapter], "Adapter does not exist");
+        require(protectedModules[_module].authorizedAdapters[_adapter], "Adapter not authorized");
+
+        protectedModules[_module].authorizedAdapters[_adapter] = false;
+        protectedModules[_module].authorizedAdaptersList.removeStorage(_adapter);
+    }
+
+    /**
+     * ADAPTER ONLY: Interact with a module registered on the SetToken. Manager must have been
+     * initialized after deployment by Methodologist. Adapter making this call must be authorized
+     * to call module if module is protected
      *
      * @param _module           Module to interact with
      * @param _data             Byte data of function to call in module
      */
-    function interactManager(address _module, bytes calldata _data) external onlyAdapter {
+    function interactManager(address _module, bytes memory _data) external onlyAdapter {
+        require(_initialized, "Manager not initialized");
+        require(_senderAuthorizedForModule(_module, msg.sender), "Adapter not authorized for module");
+
         // Invoke call to module, assume value will always be 0
         _module.functionCallWithValue(_data, 0);
     }
@@ -170,7 +247,7 @@ contract BaseManager {
      *
      * @param _module           New module to add
      */
-    function addModule(address _module) external onlyOperator {
+    function addModule(address _module) external upgradesPermitted onlyOperator {
         setToken.addModule(_module);
     }
 
@@ -180,8 +257,71 @@ contract BaseManager {
      * @param _module           Module to remove
      */
     function removeModule(address _module) external onlyOperator {
+        require(!protectedModules[_module].isProtected, "Module protected");
         setToken.removeModule(_module);
     }
+
+    /**
+     * OPERATOR ONLY: Called by operator when a module must be removed immediately for security
+     * reasons and it's unsafe to wait for the `replaceProtectedModule` mutual upgrade process to
+     * play out.  Marks a currently protected module as unprotected and deletes it from
+     * authorized adapter registries. Removes module from the SetToken. Increments the `emergencies`
+     * counter, prohibiting any further operator-only module or extension additions until
+     * `emergencyReplaceProtectedModule` decrements `emergencies` back to zero.
+     *
+     * @param _module           Module to remove
+     */
+    function emergencyRemoveProtectedModule(address _module) external onlyOperator {
+        _removeProtectedModule(_module);
+        emergencies += 1;
+    }
+
+    /**
+     * MUTUAL UPGRADE  Marks a currently protected module as unprotected and deletes it from authorized
+     * adapter registries. Removes `_oldModule` from the `protectedModulesList`. Removes old module
+     * from SetToken. Adds new module to SetToken. Marks `_newModule` as protected and authorizes
+     * new adapters for it. Adds `_newModule` module to protectedModules list.
+     *
+     * @param _oldModule        Module to remove
+     * @param _newModule        Module to add in place of removed module
+     */
+    function replaceProtectedModule(address _oldModule, address _newModule, address[] memory _newAdapters)
+        external
+        mutualUpgrade(operator, methodologist)
+    {
+        require(!protectedModules[_newModule].isProtected, "New module already protected");
+
+        _removeProtectedModule(_oldModule);
+
+        _addProtectedModule(_newModule, _newAdapters);
+    }
+
+    /**
+     * METHODOLOGIST ONLY: Called by methodologist to replace a module the operator has removed with
+     * `emergencyRemoveProtectedModule`. Adds new module to SetToken. Marks `_newModule` as protected
+     * and authorizes new adapters for it. Adds `_newModule` to protectedModules list.
+     * Sets the `upgradesPaused` flag to false, re-enabling operator-only module or extension
+     * additions until `emergencyReplaceProtectedModule` is successfully executed.
+     *
+     * @param _oldModule        Module to remove
+     * @param _newModule        Module to add in place of removed module
+     * @param _newAdapters      Adapters to authorize for replacement module
+     */
+    function emergencyReplaceProtectedModule(
+        address _newModule,
+        address[] memory _newAdapters
+    )
+        external
+        onlyMethodologist
+    {
+        require(emergencies > 0, "Not in emergency");
+        require(!protectedModules[_newModule].isProtected, "New module already protected");
+
+        _addProtectedModule(_newModule, _newAdapters);
+
+        emergencies -= 1;
+    }
+
 
     /**
      * METHODOLOGIST ONLY: Update the methodologist address
@@ -209,5 +349,95 @@ contract BaseManager {
 
     function getAdapters() external view returns(address[] memory) {
         return adapters;
+    }
+
+    /* ============ Internal ============ */
+
+
+    /**
+     * Add a new adapter that the BaseManager can call.
+     *
+     * @param _adapter           New adapter to add
+     */
+    function _addAdapter(address _adapter) internal {
+        adapters.push(_adapter);
+
+        isAdapter[_adapter] = true;
+
+        emit AdapterAdded(_adapter);
+    }
+
+    /**
+     * Marks a currently protected module as unprotected and deletes it from authorized adapter
+     * registries. Removes module from the SetToken.
+     */
+    function _removeProtectedModule(address _module) internal {
+        require(protectedModules[_module].isProtected, "Module not protected");
+
+        // Clear mapping and array entries in struct before deleting mapping entry
+        for (uint256 i = 0; i < protectedModules[_module].authorizedAdaptersList.length; i++) {
+            address adapter = protectedModules[_module].authorizedAdaptersList[i];
+            protectedModules[_module].authorizedAdapters[adapter] = false;
+        }
+
+        delete protectedModules[_module].authorizedAdaptersList;
+        delete protectedModules[_module];
+
+        protectedModulesList.removeStorage(_module);
+        setToken.removeModule(_module);
+    }
+
+    /**
+     * Adds new module to SetToken. Marks `_newModule` as protected and authorizes
+     * new adapters for it. Adds `_newModule` module to protectedModules list.
+     *
+     * @param _module    Module to add
+     * @param _adapters  Adapters to authorize for new module
+     */
+    function _addProtectedModule(address _module, address[] memory _adapters) internal {
+        setToken.addModule(_module);
+        protectedModules[_module].isProtected = true;
+        protectedModulesList.push(_module);
+
+        for (uint i = 0; i < _adapters.length; i++) {
+            if (!isAdapter[_adapters[i]]) {
+                _addAdapter(_adapters[i]);
+            }
+            protectedModules[_module].authorizedAdapters[_adapters[i]] = true;
+            protectedModules[_module].authorizedAdaptersList.push(_adapters[i]);
+        }
+    }
+
+    /**
+     * Searches the adapter mappings of each protected modules to determine if an extension
+     * is authorized by any of them. Authorized extensions cannot be unilaterally removed by
+     * the operator.
+     *
+     * @param  _adapter            Adapter to evaluate
+     * @return                     `true` if adapter is authorized for an extension, false otherwise
+     */
+    function _isAuthorizedAdapter(address _adapter) internal view returns (bool) {
+        for (uint256 i = 0; i < protectedModulesList.length; i++) {
+            if (protectedModules[protectedModulesList[i]].authorizedAdapters[_adapter]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if `_sender` (an adapter) is allowed to call a module (which may be protected)
+     *
+     * @param  _module              Address of module receiving call from sender
+     * @param  _sender              Address of adapter sending call to module
+     * @return                      True if sender allowed to call module, false otherwise
+     */
+    function _senderAuthorizedForModule(address _module, address _sender) internal view returns (bool) {
+        if (protectedModules[_module].isProtected) {
+            return protectedModules[_module].authorizedAdapters[_sender];
+        }
+
+        return false;
     }
 }

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -247,7 +247,7 @@ contract BaseManager is MutualUpgrade {
     }
 
     /**
-     * MUTUAL UPGRADE**: Authorizes an adapter for a protected module. Operator and Methodologist must
+     * MUTUAL UPGRADE: Authorizes an adapter for a protected module. Operator and Methodologist must
      * each call this function to execute the update.
      *
      * @param _module           Module to authorize adapter for
@@ -268,8 +268,9 @@ contract BaseManager is MutualUpgrade {
     }
 
     /**
-     * MUTUAL UPGRADE**: Revokes adapter authorization for a protected module. Operator and Methodologist
-     * must each call this function to execute the update.
+     * MUTUAL UPGRADE: Revokes adapter authorization for a protected module. Operator and Methodologist
+     * must each call this function to execute the update. In order to remove the extension completely
+     * from the contract removeAdapter must be called by the operator.
      *
      * @param _module           Module to revoke adapter authorization for
      * @param _adapter          Adapter to revoke authorization of
@@ -314,7 +315,8 @@ contract BaseManager is MutualUpgrade {
     }
 
     /**
-     * OPERATOR ONLY: Remove a new module from the SetToken.
+     * OPERATOR ONLY: Remove a new module from the SetToken. Any adapters associated with this
+     * module need to be removed in separate transactions via removeAdapter.
      *
      * @param _module           Module to remove
      */
@@ -327,7 +329,7 @@ contract BaseManager is MutualUpgrade {
      * OPERATOR ONLY: Marks a currently protected module as unprotected and deletes its authorized
      * adapter registries. Removes module from the SetToken. Increments the `emergencies` counter,
      * prohibiting any operator-only module or extension additions until `emergencyReplaceProtectedModule`
-     * is executed.
+     * is executed or `resolveEmergency` is called by the methodologist.
      *
      * Called by operator when a module must be removed immediately for security reasons and it's unsafe
      * to wait for a `mutualUpgrade` process to play out.
@@ -411,7 +413,7 @@ contract BaseManager is MutualUpgrade {
     }
 
     /**
-     * MUTUAL UPGRADE & ONLY EMERGENCY: Replaces a module the operator has removed with
+     * MUTUAL UPGRADE & EMERGENCY ONLY: Replaces a module the operator has removed with
      * `emergencyRemoveProtectedModule`. Operator and Methodologist must each call this function to
      *  execute the update.
      *

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -463,6 +463,18 @@ contract BaseManager is MutualUpgrade {
         return adapters;
     }
 
+    function getAuthorizedAdapters(address _module) external view returns (address[] memory) {
+        return protectedModules[_module].authorizedAdaptersList;
+    }
+
+    function isAuthorizedAdapter(address _module, address _adapter) external view returns (bool) {
+        return protectedModules[_module].authorizedAdapters[_adapter];
+    }
+
+    function getProtectedModules() external view returns (address[] memory) {
+        return protectedModulesList;
+    }
+
     /* ============ Internal ============ */
 
 

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -379,6 +379,7 @@ contract BaseManager is MutualUpgrade {
      *
      * @param _oldModule        Module to remove
      * @param _newModule        Module to add in place of removed module
+     * @param _newAdapters      Adapters to authorize for new module
      */
     function replaceProtectedModule(address _oldModule, address _newModule, address[] memory _newAdapters)
         external
@@ -550,6 +551,6 @@ contract BaseManager is MutualUpgrade {
             return protectedModules[_module].authorizedAdapters[_sender];
         }
 
-        return false;
+        return true;
     }
 }

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -523,7 +523,6 @@ contract BaseManager is MutualUpgrade {
             protectedModules[_module].authorizedAdapters[adapter] = false;
         }
 
-        delete protectedModules[_module].authorizedAdaptersList;
         delete protectedModules[_module];
 
         protectedModulesList.removeStorage(_module);

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -311,6 +311,25 @@ contract BaseManager is MutualUpgrade {
     }
 
     /**
+     * OPERATOR ONLY: Called by operator when a module must be removed immediately for security
+     * reasons and it's unsafe to wait for a `mutualUpgrade` process to play out.
+     *
+     * Marks a currently protected module as unprotected and deletes its authorized adapter registries.
+     * Removes module from the SetToken. Increments the `emergencies` counter, prohibiting any further
+     * operator-only module or extension additions until `emergencyReplaceProtectedModule` decrements
+     * `emergencies` back to zero.
+     *
+     * @param _module           Module to remove
+     */
+    function emergencyRemoveProtectedModule(address _module) external onlyOperator {
+        _unProtectModule(_module);
+        setToken.removeModule(_module);
+        emergencies += 1;
+
+        EmergencyRemovedProtectedModule(_module);
+    }
+
+    /**
      * OPERATOR ONLY: The operator uses this when they're adding new functionality and want to
      * assure the methodologist that these new features won't be unilaterally changed in the
      * future. Cannot be called during an emergency because methodologist needs to explicitly
@@ -347,26 +366,6 @@ contract BaseManager is MutualUpgrade {
 
         emit ModuleUnprotected(_module);
     }
-
-    /**
-     * OPERATOR ONLY: Called by operator when a module must be removed immediately for security
-     * reasons and it's unsafe to wait for a `mutualUpgrade` process to play out.
-     *
-     * Marks a currently protected module as unprotected and deletes its authorized adapter registries.
-     * Removes module from the SetToken. Increments the `emergencies` counter, prohibiting any further
-     * operator-only module or extension additions until `emergencyReplaceProtectedModule` decrements
-     * `emergencies` back to zero.
-     *
-     * @param _module           Module to remove
-     */
-    function emergencyRemoveProtectedModule(address _module) external onlyOperator {
-        _unProtectModule(_module);
-        setToken.removeModule(_module);
-        emergencies += 1;
-
-        EmergencyRemovedProtectedModule(_module);
-    }
-
 
     /**
      * MUTUAL UPGRADE: Used when methodologists wants to guarantee that an existing protection

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -346,7 +346,7 @@ contract BaseManager is MutualUpgrade {
         upgradesPermitted
         onlyOperator
     {
-        require(setToken.isInitializedModule(_module), "Module not added yet");
+        require(setToken.getModules().contains(_module), "Module not added yet");
         _protectModule(_module, _adapters);
 
         emit ModuleProtected(_module, _adapters);

--- a/contracts/manager/BaseManagerV2.sol
+++ b/contracts/manager/BaseManagerV2.sol
@@ -337,7 +337,7 @@ contract BaseManagerV2 is MutualUpgrade {
         setToken.removeModule(_module);
         emergencies += 1;
 
-        EmergencyRemovedProtectedModule(_module);
+        emit EmergencyRemovedProtectedModule(_module);
     }
 
     /**
@@ -412,7 +412,7 @@ contract BaseManagerV2 is MutualUpgrade {
 
         _protectModule(_newModule, _newExtensions);
 
-        ReplacedProtectedModule(_oldModule, _newModule, _newExtensions);
+        emit ReplacedProtectedModule(_oldModule, _newModule, _newExtensions);
     }
 
     /**
@@ -449,7 +449,7 @@ contract BaseManagerV2 is MutualUpgrade {
 
         emergencies -= 1;
 
-        EmergencyReplacedProtectedModule(_module, _extensions);
+        emit EmergencyReplacedProtectedModule(_module, _extensions);
     }
 
     /**

--- a/contracts/manager/BaseManagerV2.sol
+++ b/contracts/manager/BaseManagerV2.sol
@@ -1,0 +1,593 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
+
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
+import { IExtension } from "../interfaces/IExtension.sol";
+import { ISetToken } from "../interfaces/ISetToken.sol";
+import { MutualUpgrade } from "../lib/MutualUpgrade.sol";
+
+
+/**
+ * @title BaseManagerV2
+ * @author Set Protocol
+ *
+ * Smart contract manager that contains permissions and admin functionality. Implements IIP-64, supporting
+ * a registry of protected modules that can only be upgraded with methodologist consent.
+ */
+contract BaseManagerV2 is MutualUpgrade {
+    using Address for address;
+    using AddressArrayUtils for address[];
+
+    /* ============ Struct ========== */
+
+    struct ProtectedModule {
+        bool isProtected;                               // Flag set to true if module is protected
+        address[] authorizedExtensionsList;             // List of Extensions authorized to call module
+        mapping(address => bool) authorizedExtensions;  // Map of extensions authorized to call module
+    }
+
+    /* ============ Events ============ */
+
+    event ExtensionAdded(
+        address _extension
+    );
+
+    event ExtensionRemoved(
+        address _extension
+    );
+
+    event MethodologistChanged(
+        address _oldMethodologist,
+        address _newMethodologist
+    );
+
+    event OperatorChanged(
+        address _oldOperator,
+        address _newOperator
+    );
+
+    event ExtensionAuthorized(
+        address _module,
+        address _extension
+    );
+
+    event ExtensionAuthorizationRevoked(
+        address _module,
+        address _extension
+    );
+
+    event ModuleProtected(
+        address _module,
+        address[] _extensions
+    );
+
+    event ModuleUnprotected(
+        address _module
+    );
+
+    event ReplacedProtectedModule(
+        address _oldModule,
+        address _newModule,
+        address[] _newExtensions
+    );
+
+    event EmergencyReplacedProtectedModule(
+        address _module,
+        address[] _extensions
+    );
+
+    event EmergencyRemovedProtectedModule(
+        address _module
+    );
+
+    /* ============ Modifiers ============ */
+
+    /**
+     * Throws if the sender is not the SetToken operator
+     */
+    modifier onlyOperator() {
+        require(msg.sender == operator, "Must be operator");
+        _;
+    }
+
+    /**
+     * Throws if the sender is not the SetToken methodologist
+     */
+    modifier onlyMethodologist() {
+        require(msg.sender == methodologist, "Must be methodologist");
+        _;
+    }
+
+    /**
+     * Throws if the sender is not a listed extension
+     */
+    modifier onlyExtension() {
+        require(isExtension[msg.sender], "Must be extension");
+        _;
+    }
+
+    /**
+     * Throws if contract is in an emergency state following a unilateral operator removal of a
+     * protected module.
+     */
+    modifier upgradesPermitted() {
+        require(emergencies == 0, "Upgrades paused by emergency");
+        _;
+    }
+
+    /**
+     * Throws if contract is *not* in an emergency state. Emergency replacement and resolution
+     * can only happen in an emergency
+     */
+    modifier onlyEmergency() {
+        require(emergencies > 0, "Not in emergency");
+        _;
+    }
+
+    /* ============ State Variables ============ */
+
+    // Instance of SetToken
+    ISetToken public setToken;
+
+    // Array of listed extensions
+    address[] internal extensions;
+
+    // Mapping to check if extension is added
+    mapping(address => bool) public isExtension;
+
+    // Address of operator which typically executes manager only functions on Set Protocol modules
+    address public operator;
+
+    // Address of methodologist which serves as providing methodology for the index
+    address public methodologist;
+
+    // Counter incremented when the operator "emergency removes" a protected module. Decremented
+    // when methodologist executes an "emergency replacement". Operator can only add modules and
+    // extensions when `emergencies` is zero. Emergencies can only be declared "over" by mutual agreement
+    // between operator and methodologist or by the methodologist alone via `resolveEmergency`
+    uint256 public emergencies;
+
+    // Mapping of protected modules. These cannot be called or removed except by mutual upgrade.
+    mapping(address => ProtectedModule) public protectedModules;
+
+    // List of protected modules, for iteration. Used when checking that an extension removal
+    // can happen without methodologist approval
+    address[] public protectedModulesList;
+
+    // Boolean set when methodologist authorizes initialization after contract deployment.
+    // Must be true to call via `interactManager`.
+    bool public initialized;
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        ISetToken _setToken,
+        address _operator,
+        address _methodologist,
+        address[] memory _protectedModules,      // Modules to initialize as protected
+        address[][] memory _authorizedExtensions   // Extensions authorized for each protected module
+    )
+        public
+    {
+        setToken = _setToken;
+        operator = _operator;
+        methodologist = _methodologist;
+
+        for (uint256 i = 0; i < _protectedModules.length; i++) {
+            _protectModule(_protectedModules[i], _authorizedExtensions[i]);
+        }
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * ONLY METHODOLOGIST : Called by the methodologist to enable contract. All `interactManager`
+     * calls revert until this is invoked. Lets methodologist review and authorize initial protected
+     * module settings.
+     */
+    function authorizeInitialization() external onlyMethodologist {
+        require(!initialized, "Initialization authorized");
+        initialized = true;
+    }
+
+    /**
+     * MUTUAL UPGRADE: Update the SetToken manager address. Operator and Methodologist must each call
+     * this function to execute the update.
+     *
+     * @param _newManager           New manager address
+     */
+    function setManager(address _newManager) external mutualUpgrade(operator, methodologist) {
+        require(_newManager != address(0), "Zero address not valid");
+        setToken.setManager(_newManager);
+    }
+
+    /**
+     * OPERATOR ONLY: Add a new extension that the BaseManager can call.
+     *
+     * @param _extension           New extension to add
+     */
+    function addExtension(address _extension) external upgradesPermitted onlyOperator {
+        require(!isExtension[_extension], "Extension already exists");
+        require(address(IExtension(_extension).manager()) == address(this), "Extension manager invalid");
+
+        _addExtension(_extension);
+    }
+
+    /**
+     * OPERATOR ONLY: Remove an existing extension tracked by the BaseManager.
+     *
+     * @param _extension           Old extension to remove
+     */
+    function removeExtension(address _extension) external onlyOperator {
+        require(isExtension[_extension], "Extension does not exist");
+        require(!_isAuthorizedExtension(_extension), "Extension used by protected module");
+
+        extensions.removeStorage(_extension);
+
+        isExtension[_extension] = false;
+
+        emit ExtensionRemoved(_extension);
+    }
+
+    /**
+     * MUTUAL UPGRADE: Authorizes an extension for a protected module. Operator and Methodologist must
+     * each call this function to execute the update. Adds extension to manager if not already present.
+     *
+     * @param _module           Module to authorize extension for
+     * @param _extension          Extension to authorize for module
+     */
+    function authorizeExtension(address _module, address _extension)
+        external
+        mutualUpgrade(operator, methodologist)
+    {
+        require(protectedModules[_module].isProtected, "Module not protected");
+        require(!protectedModules[_module].authorizedExtensions[_extension], "Extension already authorized");
+
+        if (!isExtension[_extension]) {
+            _addExtension(_extension);
+        }
+
+        protectedModules[_module].authorizedExtensions[_extension] = true;
+        protectedModules[_module].authorizedExtensionsList.push(_extension);
+
+        emit ExtensionAuthorized(_module, _extension);
+    }
+
+    /**
+     * MUTUAL UPGRADE: Revokes extension authorization for a protected module. Operator and Methodologist
+     * must each call this function to execute the update. In order to remove the extension completely
+     * from the contract removeExtension must be called by the operator.
+     *
+     * @param _module           Module to revoke extension authorization for
+     * @param _extension          Extension to revoke authorization of
+     */
+    function revokeExtensionAuthorization(address _module, address _extension)
+        external
+        mutualUpgrade(operator, methodologist)
+    {
+        require(protectedModules[_module].isProtected, "Module not protected");
+        require(isExtension[_extension], "Extension does not exist");
+        require(protectedModules[_module].authorizedExtensions[_extension], "Extension not authorized");
+
+        protectedModules[_module].authorizedExtensions[_extension] = false;
+        protectedModules[_module].authorizedExtensionsList.removeStorage(_extension);
+
+        emit ExtensionAuthorizationRevoked(_module, _extension);
+    }
+
+    /**
+     * ADAPTER ONLY: Interact with a module registered on the SetToken. Manager initialization must
+     * have been authorized by methodologist. Extension making this call must be authorized
+     * to call module if module is protected.
+     *
+     * @param _module           Module to interact with
+     * @param _data             Byte data of function to call in module
+     */
+    function interactManager(address _module, bytes memory _data) external onlyExtension {
+        require(initialized, "Manager not initialized");
+        require(_senderAuthorizedForModule(_module, msg.sender), "Extension not authorized for module");
+
+        // Invoke call to module, assume value will always be 0
+        _module.functionCallWithValue(_data, 0);
+    }
+
+    /**
+     * OPERATOR ONLY: Add a new module to the SetToken.
+     *
+     * @param _module           New module to add
+     */
+    function addModule(address _module) external upgradesPermitted onlyOperator {
+        setToken.addModule(_module);
+    }
+
+    /**
+     * OPERATOR ONLY: Remove a new module from the SetToken. Any extensions associated with this
+     * module need to be removed in separate transactions via removeExtension.
+     *
+     * @param _module           Module to remove
+     */
+    function removeModule(address _module) external onlyOperator {
+        require(!protectedModules[_module].isProtected, "Module protected");
+        setToken.removeModule(_module);
+    }
+
+    /**
+     * OPERATOR ONLY: Marks a currently protected module as unprotected and deletes its authorized
+     * extension registries. Removes module from the SetToken. Increments the `emergencies` counter,
+     * prohibiting any operator-only module or extension additions until `emergencyReplaceProtectedModule`
+     * is executed or `resolveEmergency` is called by the methodologist.
+     *
+     * Called by operator when a module must be removed immediately for security reasons and it's unsafe
+     * to wait for a `mutualUpgrade` process to play out.
+     *
+     * NOTE: If removing a fee module, you can ensure all fees are distributed by calling distribute
+     * on the module's de-authorized fee extension after this call.
+     *
+     * @param _module           Module to remove
+     */
+    function emergencyRemoveProtectedModule(address _module) external onlyOperator {
+        _unProtectModule(_module);
+        setToken.removeModule(_module);
+        emergencies += 1;
+
+        EmergencyRemovedProtectedModule(_module);
+    }
+
+    /**
+     * OPERATOR ONLY: Marks an existing module as protected and authorizes existing extensions for
+     * it. Adds module to the protected modules list
+     *
+     * The operator uses this when they're adding new features and want to assure the methodologist
+     * they won't be unilaterally changed in the future. Cannot be called during an emergency because
+     * methodologist needs to explicitly approve protection arrangements under those conditions.
+     *
+     * NOTE: If adding a fee extension while protecting a fee module, it's important to set the
+     * module `feeRecipient` to the new extension's address (ideally before this call).
+     *
+     * @param  _module          Module to protect
+     * @param  _extensions        Array of extensions to authorize for protected module
+     */
+    function protectModule(address _module, address[] memory _extensions)
+        external
+        upgradesPermitted
+        onlyOperator
+    {
+        require(setToken.getModules().contains(_module), "Module not added yet");
+        _protectModule(_module, _extensions);
+
+        emit ModuleProtected(_module, _extensions);
+    }
+
+    /**
+     * METHODOLOGIST ONLY: Marks a currently protected module as unprotected and deletes its authorized
+     * extension registries. Removes old module from the protected modules list.
+     *
+     * Called by the methodologist when they want to cede control over a protected module without triggering
+     * an emergency (for example, to remove it because its dead).
+     *
+     * @param  _module          Module to revoke protections for
+     */
+    function unProtectModule(address _module) external onlyMethodologist {
+        _unProtectModule(_module);
+
+        emit ModuleUnprotected(_module);
+    }
+
+    /**
+     * MUTUAL UPGRADE: Replaces a protected module. Operator and Methodologist must each call this
+     * function to execute the update.
+     *
+     * > Marks a currently protected module as unprotected
+     * > Deletes its authorized extension registries.
+     * > Removes old module from SetToken.
+     * > Adds new module to SetToken.
+     * > Marks `_newModule` as protected and authorizes new extensions for it.
+     *
+     * Used when methodologists wants to guarantee that an existing protection arrangement is replaced
+     * with a suitable substitute (ex: upgrading a StreamingFeeSplitExtension).
+     *
+     * NOTE: If replacing a fee module, it's necessary to set the module `feeRecipient` to be
+     * the new fee extension address after this call. Any fees remaining in the old module's
+     * de-authorized extensions can be distributed by calling `distribute()` on the old extension.
+     *
+     * @param _oldModule        Module to remove
+     * @param _newModule        Module to add in place of removed module
+     * @param _newExtensions      Extensions to authorize for new module
+     */
+    function replaceProtectedModule(address _oldModule, address _newModule, address[] memory _newExtensions)
+        external
+        mutualUpgrade(operator, methodologist)
+    {
+        _unProtectModule(_oldModule);
+
+        setToken.removeModule(_oldModule);
+        setToken.addModule(_newModule);
+
+        _protectModule(_newModule, _newExtensions);
+
+        ReplacedProtectedModule(_oldModule, _newModule, _newExtensions);
+    }
+
+    /**
+     * MUTUAL UPGRADE & EMERGENCY ONLY: Replaces a module the operator has removed with
+     * `emergencyRemoveProtectedModule`. Operator and Methodologist must each call this function to
+     *  execute the update.
+     *
+     * > Adds new module to SetToken.
+     * > Marks `_newModule` as protected and authorizes new extensions for it.
+     * > Adds `_newModule` to protectedModules list.
+     * > Decrements the emergencies counter,
+     *
+     * Used when methodologist wants to guarantee that a protection arrangement which was
+     * removed in an emergency is replaced with a suitable substitute. Operator's ability to add modules
+     * or extensions is restored after invoking this method (if this is the only emergency.)
+     *
+     * NOTE: If replacing a fee module, it's necessary to set the module `feeRecipient` to be
+     * the new fee extension address after this call. Any fees remaining in the old module's
+     * de-authorized extensions can be distributed by calling `distribute()` on the old extension.
+     *
+     * @param _module        Module to add in place of removed module
+     * @param _extensions      Array of extensions to authorize for replacement module
+     */
+    function emergencyReplaceProtectedModule(
+        address _module,
+        address[] memory _extensions
+    )
+        external
+        mutualUpgrade(operator, methodologist)
+        onlyEmergency
+    {
+        setToken.addModule(_module);
+        _protectModule(_module, _extensions);
+
+        emergencies -= 1;
+
+        EmergencyReplacedProtectedModule(_module, _extensions);
+    }
+
+    /**
+     * METHODOLOGIST ONLY & EMERGENCY ONLY: Decrements the emergencies counter.
+     *
+     * Allows a methodologist to exit a state of emergency without replacing a protected module that
+     * was removed. This could happen if the module has no viable substitute or operator and methodologist
+     * agree that restoring normal operations is the best way forward.
+     */
+    function resolveEmergency() external onlyMethodologist onlyEmergency {
+        emergencies -= 1;
+    }
+
+    /**
+     * METHODOLOGIST ONLY: Update the methodologist address
+     *
+     * @param _newMethodologist           New methodologist address
+     */
+    function setMethodologist(address _newMethodologist) external onlyMethodologist {
+        emit MethodologistChanged(methodologist, _newMethodologist);
+
+        methodologist = _newMethodologist;
+    }
+
+    /**
+     * OPERATOR ONLY: Update the operator address
+     *
+     * @param _newOperator           New operator address
+     */
+    function setOperator(address _newOperator) external onlyOperator {
+        emit OperatorChanged(operator, _newOperator);
+
+        operator = _newOperator;
+    }
+
+    /* ============ External Getters ============ */
+
+    function getExtensions() external view returns(address[] memory) {
+        return extensions;
+    }
+
+    function getAuthorizedExtensions(address _module) external view returns (address[] memory) {
+        return protectedModules[_module].authorizedExtensionsList;
+    }
+
+    function isAuthorizedExtension(address _module, address _extension) external view returns (bool) {
+        return protectedModules[_module].authorizedExtensions[_extension];
+    }
+
+    function getProtectedModules() external view returns (address[] memory) {
+        return protectedModulesList;
+    }
+
+    /* ============ Internal ============ */
+
+
+    /**
+     * Add a new extension that the BaseManager can call.
+     */
+    function _addExtension(address _extension) internal {
+        extensions.push(_extension);
+
+        isExtension[_extension] = true;
+
+        emit ExtensionAdded(_extension);
+    }
+
+    /**
+     * Marks a currently protected module as unprotected and deletes it from authorized extension
+     * registries. Removes module from the SetToken.
+     */
+    function _unProtectModule(address _module) internal {
+        require(protectedModules[_module].isProtected, "Module not protected");
+
+        // Clear mapping and array entries in struct before deleting mapping entry
+        for (uint256 i = 0; i < protectedModules[_module].authorizedExtensionsList.length; i++) {
+            address extension = protectedModules[_module].authorizedExtensionsList[i];
+            protectedModules[_module].authorizedExtensions[extension] = false;
+        }
+
+        delete protectedModules[_module];
+
+        protectedModulesList.removeStorage(_module);
+    }
+
+    /**
+     * Adds new module to SetToken. Marks `_newModule` as protected and authorizes
+     * new extensions for it. Adds `_newModule` module to protectedModules list.
+     */
+    function _protectModule(address _module, address[] memory _extensions) internal {
+        require(!protectedModules[_module].isProtected, "Module already protected");
+
+        protectedModules[_module].isProtected = true;
+        protectedModulesList.push(_module);
+
+        for (uint i = 0; i < _extensions.length; i++) {
+            if (!isExtension[_extensions[i]]) {
+                _addExtension(_extensions[i]);
+            }
+            protectedModules[_module].authorizedExtensions[_extensions[i]] = true;
+            protectedModules[_module].authorizedExtensionsList.push(_extensions[i]);
+        }
+    }
+
+    /**
+     * Searches the extension mappings of each protected modules to determine if an extension
+     * is authorized by any of them. Authorized extensions cannot be unilaterally removed by
+     * the operator.
+     */
+    function _isAuthorizedExtension(address _extension) internal view returns (bool) {
+        for (uint256 i = 0; i < protectedModulesList.length; i++) {
+            if (protectedModules[protectedModulesList[i]].authorizedExtensions[_extension]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if `_sender` (an extension) is allowed to call a module (which may be protected)
+     */
+    function _senderAuthorizedForModule(address _module, address _sender) internal view returns (bool) {
+        if (protectedModules[_module].isProtected) {
+            return protectedModules[_module].authorizedExtensions[_sender];
+        }
+
+        return true;
+    }
+}

--- a/contracts/manager/BaseManagerV2.sol
+++ b/contracts/manager/BaseManagerV2.sol
@@ -261,12 +261,7 @@ contract BaseManagerV2 is MutualUpgrade {
         require(protectedModules[_module].isProtected, "Module not protected");
         require(!protectedModules[_module].authorizedExtensions[_extension], "Extension already authorized");
 
-        if (!isExtension[_extension]) {
-            _addExtension(_extension);
-        }
-
-        protectedModules[_module].authorizedExtensions[_extension] = true;
-        protectedModules[_module].authorizedExtensionsList.push(_extension);
+        _authorizeExtension(_module, _extension);
 
         emit ExtensionAuthorized(_module, _extension);
     }
@@ -557,12 +552,20 @@ contract BaseManagerV2 is MutualUpgrade {
         protectedModulesList.push(_module);
 
         for (uint i = 0; i < _extensions.length; i++) {
-            if (!isExtension[_extensions[i]]) {
-                _addExtension(_extensions[i]);
-            }
-            protectedModules[_module].authorizedExtensions[_extensions[i]] = true;
-            protectedModules[_module].authorizedExtensionsList.push(_extensions[i]);
+            _authorizeExtension(_module, _extensions[i]);
         }
+    }
+
+    /**
+     * Adds extension if not already added and marks extension as authorized for module
+     */
+    function _authorizeExtension(address _module, address _extension) internal {
+        if (!isExtension[_extension]) {
+            _addExtension(_extension);
+        }
+
+        protectedModules[_module].authorizedExtensions[_extension] = true;
+        protectedModules[_module].authorizedExtensionsList.push(_extension);
     }
 
     /**

--- a/contracts/manager/BaseManagerV2.sol
+++ b/contracts/manager/BaseManagerV2.sol
@@ -181,19 +181,13 @@ contract BaseManagerV2 is MutualUpgrade {
     constructor(
         ISetToken _setToken,
         address _operator,
-        address _methodologist,
-        address[] memory _protectedModules,      // Modules to initialize as protected
-        address[][] memory _authorizedExtensions   // Extensions authorized for each protected module
+        address _methodologist
     )
         public
     {
         setToken = _setToken;
         operator = _operator;
         methodologist = _methodologist;
-
-        for (uint256 i = 0; i < _protectedModules.length; i++) {
-            _protectModule(_protectedModules[i], _authorizedExtensions[i]);
-        }
     }
 
     /* ============ External Functions ============ */

--- a/contracts/mocks/BaseExtensionMock.sol
+++ b/contracts/mocks/BaseExtensionMock.sol
@@ -18,12 +18,12 @@
 
 pragma solidity 0.6.10;
 
-import { BaseAdapter } from "../lib/BaseAdapter.sol";
+import { BaseExtension } from "../lib/BaseExtension.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
 
-contract BaseAdapterMock is BaseAdapter {
+contract BaseExtensionMock is BaseExtension {
 
-    constructor(IBaseManager _manager) public BaseAdapter(_manager) {}
+    constructor(IBaseManager _manager) public BaseExtension(_manager) {}
 
     /* ============ External Functions ============ */
 

--- a/contracts/mocks/TradeAdapterMock.sol
+++ b/contracts/mocks/TradeAdapterMock.sol
@@ -16,7 +16,7 @@ contract TradeAdapterMock {
         uint256 balance = ERC20(_token).balanceOf(address(this));
         require(ERC20(_token).transfer(msg.sender, balance), "ERC20 transfer failed");
     }
-    
+
     /* ============ Trade Functions ============ */
 
     function trade(

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -34,6 +34,8 @@ const config: HardhatUserConfig = {
     hardhat: {
       forking: (process.env.FORK) ? forkingConfig : undefined,
       accounts: getHardhatPrivateKeys(),
+      gas: 12000000,
+      blockGasLimit: 12000000,
     },
     localhost: {
       url: "http://127.0.0.1:8545",

--- a/tasks/subtasks.ts
+++ b/tasks/subtasks.ts
@@ -14,7 +14,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT)
 
     // These changes should be skipped when publishing to npm.
     // They override ethers' gas estimation
-    if (!process.env.SKIP_ABI_GAS_MODS){
+    if (!process.env.SKIP_ABI_GAS_MODS) {
       artifact.abi = addGasToAbiMethods(network.config, artifact.abi);
     }
 

--- a/test/adapters/feeSplitAdapter.spec.ts
+++ b/test/adapters/feeSplitAdapter.spec.ts
@@ -59,8 +59,11 @@ describe("FeeSplitAdapter", () => {
     baseManagerV2 = await deployer.manager.deployBaseManager(
       setToken.address,
       operator.address,
-      methodologist.address
+      methodologist.address,
+      [],
+      [[]]
     );
+    await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 
     const feeRecipient = baseManagerV2.address;
     const maxStreamingFeePercentage = ether(.1);

--- a/test/adapters/feeSplitAdapter.spec.ts
+++ b/test/adapters/feeSplitAdapter.spec.ts
@@ -289,8 +289,11 @@ describe("FeeSplitAdapter", () => {
             expect(feeState.streamingFeePercentage).to.eq(subjectNewFee);
           });
 
+          it("should not leave a SetToken balance in the manager", async() => {
+
+          });
+
           it("should send correct amount of fees to operator and methodologist", async () => {
-            const preManagerBalance = await setToken.balanceOf(baseManagerV2.address);
             const feeState: any = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
             const totalSupply = await setToken.totalSupply();
 
@@ -307,9 +310,17 @@ describe("FeeSplitAdapter", () => {
 
             const feeInflation = getStreamingFeeInflationAmount(expectedFeeInflation, totalSupply);
 
+            const expectedMintRedeemFees = preciseMul(mintedTokens, ether(.01));
+            const expectedOperatorTake = preciseMul(feeInflation.add(expectedMintRedeemFees), operatorSplit);
+            const expectedMethodologistTake = feeInflation.add(expectedMintRedeemFees).sub(expectedOperatorTake);
+
+            const operatorBalance = await setToken.balanceOf(operator.address);
+            const methodologistBalance = await setToken.balanceOf(methodologist.address);
             const postManagerBalance = await setToken.balanceOf(baseManagerV2.address);
 
-            expect(postManagerBalance.sub(preManagerBalance)).to.eq(feeInflation);
+            expect(operatorBalance).to.eq(expectedOperatorTake);
+            expect(methodologistBalance).to.eq(expectedMethodologistTake);
+            expect(postManagerBalance).to.eq(ZERO);
           });
         });
       });
@@ -346,7 +357,6 @@ describe("FeeSplitAdapter", () => {
           });
 
           it("should send correct amount of fees to operator and methodologist", async () => {
-            const preManagerBalance = await setToken.balanceOf(baseManagerV2.address);
             const feeState: any = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
             const totalSupply = await setToken.totalSupply();
 
@@ -363,9 +373,18 @@ describe("FeeSplitAdapter", () => {
 
             const feeInflation = getStreamingFeeInflationAmount(expectedFeeInflation, totalSupply);
 
+            const expectedMintRedeemFees = preciseMul(mintedTokens, ether(.01));
+            const expectedOperatorTake = preciseMul(feeInflation.add(expectedMintRedeemFees), operatorSplit);
+            const expectedMethodologistTake = feeInflation.add(expectedMintRedeemFees).sub(expectedOperatorTake);
+
+            const operatorBalance = await setToken.balanceOf(operator.address);
+            const methodologistBalance = await setToken.balanceOf(methodologist.address);
             const postManagerBalance = await setToken.balanceOf(baseManagerV2.address);
 
-            expect(postManagerBalance.sub(preManagerBalance)).to.eq(feeInflation);
+
+            expect(operatorBalance).to.eq(expectedOperatorTake);
+            expect(methodologistBalance).to.eq(expectedMethodologistTake);
+            expect(postManagerBalance).to.eq(ZERO);
           });
         });
       });

--- a/test/adapters/feeSplitExtension.spec.ts
+++ b/test/adapters/feeSplitExtension.spec.ts
@@ -106,7 +106,7 @@ describe("FeeSplitExtension", () => {
     });
 
     async function subject(): Promise<FeeSplitExtension> {
-      return await deployer.adapters.deployFeeSplitExtension(
+      return await deployer.extensions.deployFeeSplitExtension(
         subjectManager,
         subjectStreamingFeeModule,
         subjectDebtIssuanceModule,
@@ -162,7 +162,7 @@ describe("FeeSplitExtension", () => {
     const operatorSplit: BigNumber = ether(.7);
 
     beforeEach(async () => {
-      feeExtension = await deployer.adapters.deployFeeSplitExtension(
+      feeExtension = await deployer.extensions.deployFeeSplitExtension(
         baseManagerV2.address,
         setV2Setup.streamingFeeModule.address,
         setV2Setup.debtIssuanceModule.address,

--- a/test/adapters/feeSplitExtension.spec.ts
+++ b/test/adapters/feeSplitExtension.spec.ts
@@ -61,9 +61,7 @@ describe("FeeSplitExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 

--- a/test/adapters/feeSplitExtension.spec.ts
+++ b/test/adapters/feeSplitExtension.spec.ts
@@ -3,7 +3,7 @@ import "module-alias/register";
 import { solidityKeccak256 } from "ethers/lib/utils";
 import { Address, Account } from "@utils/types";
 import { ADDRESS_ZERO, ZERO, ONE_DAY_IN_SECONDS, ONE_YEAR_IN_SECONDS } from "@utils/constants";
-import { FeeSplitAdapter, BaseManagerV2 } from "@utils/contracts/index";
+import { FeeSplitExtension, BaseManagerV2 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -25,7 +25,7 @@ import { BigNumber, ContractTransaction } from "ethers";
 
 const expect = getWaffleExpect();
 
-describe("FeeSplitAdapter", () => {
+describe("FeeSplitExtension", () => {
   let owner: Account;
   let methodologist: Account;
   let operator: Account;
@@ -36,7 +36,7 @@ describe("FeeSplitAdapter", () => {
   let setToken: SetToken;
 
   let baseManagerV2: BaseManagerV2;
-  let feeExtension: FeeSplitAdapter;
+  let feeExtension: FeeSplitExtension;
 
   before(async () => {
     [
@@ -105,8 +105,8 @@ describe("FeeSplitAdapter", () => {
       subjectOperatorFeeRecipient = operatorFeeRecipient.address;
     });
 
-    async function subject(): Promise<FeeSplitAdapter> {
-      return await deployer.adapters.deployFeeSplitAdapter(
+    async function subject(): Promise<FeeSplitExtension> {
+      return await deployer.adapters.deployFeeSplitExtension(
         subjectManager,
         subjectStreamingFeeModule,
         subjectDebtIssuanceModule,
@@ -162,7 +162,7 @@ describe("FeeSplitAdapter", () => {
     const operatorSplit: BigNumber = ether(.7);
 
     beforeEach(async () => {
-      feeExtension = await deployer.adapters.deployFeeSplitAdapter(
+      feeExtension = await deployer.adapters.deployFeeSplitExtension(
         baseManagerV2.address,
         setV2Setup.streamingFeeModule.address,
         setV2Setup.debtIssuanceModule.address,

--- a/test/adapters/flexibleLeverageStrategyExtension.spec.ts
+++ b/test/adapters/flexibleLeverageStrategyExtension.spec.ts
@@ -12,7 +12,7 @@ import {
   ExchangeSettings
 } from "@utils/types";
 import { ADDRESS_ZERO, ONE, TWO, THREE, ZERO, EMPTY_BYTES, MAX_UINT_256 } from "@utils/constants";
-import { FlexibleLeverageStrategyExtension, BaseManager, TradeAdapterMock, ChainlinkAggregatorV3Mock } from "@utils/contracts/index";
+import { FlexibleLeverageStrategyExtension, BaseManagerV2, TradeAdapterMock, ChainlinkAggregatorV3Mock } from "@utils/contracts/index";
 import { CompoundLeverageModule, ContractCallerMock, DebtIssuanceModule, SetToken } from "@utils/contracts/setV2";
 import { CEther, CERc20 } from "@utils/contracts/compound";
 import DeployHelper from "@utils/deploys";
@@ -68,7 +68,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
   let flexibleLeverageStrategyExtension: FlexibleLeverageStrategyExtension;
   let compoundLeverageModule: CompoundLeverageModule;
   let debtIssuanceModule: DebtIssuanceModule;
-  let baseManagerV2: BaseManager;
+  let baseManagerV2: BaseManagerV2;
 
   let chainlinkCollateralPriceMock: ChainlinkAggregatorV3Mock;
   let chainlinkBorrowPriceMock: ChainlinkAggregatorV3Mock;
@@ -191,7 +191,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       [setV2Setup.usdc.address]
     );
 
-    baseManagerV2 = await deployer.manager.deployBaseManager(
+    baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       owner.address,
       methodologist.address,

--- a/test/adapters/flexibleLeverageStrategyExtension.spec.ts
+++ b/test/adapters/flexibleLeverageStrategyExtension.spec.ts
@@ -275,7 +275,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     );
 
     // Add adapter
-    await baseManagerV2.connect(owner.wallet).addAdapter(flexibleLeverageStrategyExtension.address);
+    await baseManagerV2.connect(owner.wallet).addExtension(flexibleLeverageStrategyExtension.address);
   };
 
   describe("#constructor", async () => {

--- a/test/adapters/flexibleLeverageStrategyExtension.spec.ts
+++ b/test/adapters/flexibleLeverageStrategyExtension.spec.ts
@@ -195,7 +195,10 @@ describe("FlexibleLeverageStrategyExtension", () => {
       setToken.address,
       owner.address,
       methodologist.address,
+      [],
+      [[]]
     );
+    await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 
     // Transfer ownership to ic manager
     if ((await setToken.manager()) == owner.address) {

--- a/test/adapters/flexibleLeverageStrategyExtension.spec.ts
+++ b/test/adapters/flexibleLeverageStrategyExtension.spec.ts
@@ -130,7 +130,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     debtIssuanceModule = await deployer.setV2.deployDebtIssuanceModule(setV2Setup.controller.address);
     await setV2Setup.controller.addModule(debtIssuanceModule.address);
 
-    // Deploy mock trade adapter
+    // Deploy mock trade extension
     tradeAdapterMock = await deployer.mocks.deployTradeAdapterMock();
     await setV2Setup.integrationRegistry.addIntegration(
       compoundLeverageModule.address,
@@ -138,7 +138,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       tradeAdapterMock.address,
     );
 
-    // Deploy mock trade adapter 2
+    // Deploy mock trade extension 2
     tradeAdapterMock2 = await deployer.mocks.deployTradeAdapterMock();
     await setV2Setup.integrationRegistry.addIntegration(
       compoundLeverageModule.address,
@@ -205,7 +205,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       await setToken.connect(owner.wallet).setManager(baseManagerV2.address);
     }
 
-    // Deploy adapter
+    // Deploy extension
     const targetLeverageRatio = customTargetLeverageRatio || ether(2);
     const minLeverageRatio = customMinLeverageRatio || ether(1.7);
     const maxLeverageRatio = ether(2.3);
@@ -264,7 +264,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       deleverExchangeData: EMPTY_BYTES,
     };
 
-    flexibleLeverageStrategyExtension = await deployer.adapters.deployFlexibleLeverageStrategyExtension(
+    flexibleLeverageStrategyExtension = await deployer.extensions.deployFlexibleLeverageStrategyExtension(
       baseManagerV2.address,
       strategy,
       methodology,
@@ -274,7 +274,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       [ exchangeSettings ]
     );
 
-    // Add adapter
+    // Add extension
     await baseManagerV2.connect(owner.wallet).addExtension(flexibleLeverageStrategyExtension.address);
   };
 
@@ -333,7 +333,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     });
 
     async function subject(): Promise<FlexibleLeverageStrategyExtension> {
-      return await deployer.adapters.deployFlexibleLeverageStrategyExtension(
+      return await deployer.extensions.deployFlexibleLeverageStrategyExtension(
         subjectManagerAddress,
         subjectContractSettings,
         subjectMethodologySettings,

--- a/test/adapters/flexibleLeverageStrategyExtension.spec.ts
+++ b/test/adapters/flexibleLeverageStrategyExtension.spec.ts
@@ -194,9 +194,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       owner.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 

--- a/test/adapters/gimExtension.spec.ts
+++ b/test/adapters/gimExtension.spec.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { Address, Account } from "@utils/types";
 import { ADDRESS_ZERO, ZERO } from "@utils/constants";
-import { GIMExtension, BaseManager } from "@utils/contracts/index";
+import { GIMExtension, BaseManagerV2 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -34,7 +34,7 @@ describe("GIMExtension", () => {
   let deployer: DeployHelper;
   let setToken: SetToken;
 
-  let baseManagerV2: BaseManager;
+  let baseManagerV2: BaseManagerV2;
   let gimExtension: GIMExtension;
 
   before(async () => {
@@ -83,7 +83,7 @@ describe("GIMExtension", () => {
     );
 
     // Deploy BaseManager
-    baseManagerV2 = await deployer.manager.deployBaseManager(
+    baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
       methodologist.address,

--- a/test/adapters/gimExtension.spec.ts
+++ b/test/adapters/gimExtension.spec.ts
@@ -105,7 +105,7 @@ describe("GIMExtension", () => {
     });
 
     async function subject(): Promise<GIMExtension> {
-      return await deployer.adapters.deployGIMExtension(
+      return await deployer.extensions.deployGIMExtension(
         subjectManager,
         subjectGeneralIndexModule
       );
@@ -135,7 +135,7 @@ describe("GIMExtension", () => {
 
   context("when GIM extension is deployed and module needs to be initialized", async () => {
     beforeEach(async () => {
-      gimExtension = await deployer.adapters.deployGIMExtension(
+      gimExtension = await deployer.extensions.deployGIMExtension(
         baseManagerV2.address,
         setV2Setup.generalIndexModule.address
       );

--- a/test/adapters/gimExtension.spec.ts
+++ b/test/adapters/gimExtension.spec.ts
@@ -86,9 +86,7 @@ describe("GIMExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
   });

--- a/test/adapters/gimExtension.spec.ts
+++ b/test/adapters/gimExtension.spec.ts
@@ -140,7 +140,7 @@ describe("GIMExtension", () => {
         setV2Setup.generalIndexModule.address
       );
 
-      await baseManagerV2.connect(operator.wallet).addAdapter(gimExtension.address);
+      await baseManagerV2.connect(operator.wallet).addExtension(gimExtension.address);
 
       await gimExtension.connect(operator.wallet).updateCallerStatus([approvedCaller.address], [true]);
 

--- a/test/adapters/gimExtension.spec.ts
+++ b/test/adapters/gimExtension.spec.ts
@@ -86,8 +86,11 @@ describe("GIMExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManager(
       setToken.address,
       operator.address,
-      methodologist.address
+      methodologist.address,
+      [],
+      [[]]
     );
+    await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
   });
 
   addSnapshotBeforeRestoreAfterEach();

--- a/test/adapters/governanceAdapter.spec.ts
+++ b/test/adapters/governanceAdapter.spec.ts
@@ -67,8 +67,11 @@ describe("GovernanceAdapter", () => {
     baseManagerV2 = await deployer.manager.deployBaseManager(
       setToken.address,
       operator.address,
-      methodologist.address
+      methodologist.address,
+      [],
+      [[]]
     );
+    await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
   });
 
   addSnapshotBeforeRestoreAfterEach();

--- a/test/adapters/governanceAdapter.spec.ts
+++ b/test/adapters/governanceAdapter.spec.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { Address, Account } from "@utils/types";
 import { ADDRESS_ZERO, EMPTY_BYTES, ONE, TWO } from "@utils/constants";
-import { GovernanceAdapter, BaseManager, GovernanceAdapterMock } from "@utils/contracts/index";
+import { GovernanceAdapter, BaseManagerV2, GovernanceAdapterMock } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -30,7 +30,7 @@ describe("GovernanceAdapter", () => {
   let deployer: DeployHelper;
   let setToken: SetToken;
 
-  let baseManagerV2: BaseManager;
+  let baseManagerV2: BaseManagerV2;
   let governanceAdapter: GovernanceAdapter;
   let governanceMock: GovernanceAdapterMock;
 
@@ -64,7 +64,7 @@ describe("GovernanceAdapter", () => {
     );
 
     // Deploy BaseManager
-    baseManagerV2 = await deployer.manager.deployBaseManager(
+    baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
       methodologist.address,

--- a/test/adapters/governanceAdapter.spec.ts
+++ b/test/adapters/governanceAdapter.spec.ts
@@ -121,7 +121,7 @@ describe("GovernanceAdapter", () => {
         setV2Setup.governanceModule.address
       );
 
-      await baseManagerV2.connect(operator.wallet).addAdapter(governanceAdapter.address);
+      await baseManagerV2.connect(operator.wallet).addExtension(governanceAdapter.address);
 
       await governanceAdapter.connect(operator.wallet).updateCallerStatus([approvedCaller.address], [true]);
 

--- a/test/adapters/governanceExtension.spec.ts
+++ b/test/adapters/governanceExtension.spec.ts
@@ -67,9 +67,7 @@ describe("GovernanceExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
   });

--- a/test/adapters/governanceExtension.spec.ts
+++ b/test/adapters/governanceExtension.spec.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { Address, Account } from "@utils/types";
 import { ADDRESS_ZERO, EMPTY_BYTES, ONE, TWO } from "@utils/constants";
-import { GovernanceAdapter, BaseManagerV2, GovernanceAdapterMock } from "@utils/contracts/index";
+import { GovernanceExtension, BaseManagerV2, GovernanceAdapterMock } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -18,7 +18,7 @@ import { BigNumber, ContractTransaction } from "ethers";
 
 const expect = getWaffleExpect();
 
-describe("GovernanceAdapter", () => {
+describe("GovernanceExtension", () => {
   let owner: Account;
   let methodologist: Account;
   let operator: Account;
@@ -31,7 +31,7 @@ describe("GovernanceAdapter", () => {
   let setToken: SetToken;
 
   let baseManagerV2: BaseManagerV2;
-  let governanceAdapter: GovernanceAdapter;
+  let governanceExtension: GovernanceExtension;
   let governanceMock: GovernanceAdapterMock;
 
   const governanceMockName: string = "GovernanceMock";
@@ -85,45 +85,45 @@ describe("GovernanceAdapter", () => {
       subjectGovernanceModule = setV2Setup.governanceModule.address;
     });
 
-    async function subject(): Promise<GovernanceAdapter> {
-      return await deployer.adapters.deployGovernanceAdapter(
+    async function subject(): Promise<GovernanceExtension> {
+      return await deployer.extensions.deployGovernanceExtension(
         subjectManager,
         subjectGovernanceModule
       );
     }
 
     it("should set the correct SetToken address", async () => {
-      const governanceAdapter = await subject();
+      const governanceExtension = await subject();
 
-      const actualToken = await governanceAdapter.setToken();
+      const actualToken = await governanceExtension.setToken();
       expect(actualToken).to.eq(setToken.address);
     });
 
     it("should set the correct manager address", async () => {
-      const governanceAdapter = await subject();
+      const governanceExtension = await subject();
 
-      const actualManager = await governanceAdapter.manager();
+      const actualManager = await governanceExtension.manager();
       expect(actualManager).to.eq(baseManagerV2.address);
     });
 
     it("should set the correct governance module address", async () => {
-      const governanceAdapter = await subject();
+      const governanceExtension = await subject();
 
-      const actualStreamingFeeModule = await governanceAdapter.governanceModule();
+      const actualStreamingFeeModule = await governanceExtension.governanceModule();
       expect(actualStreamingFeeModule).to.eq(subjectGovernanceModule);
     });
   });
 
-  context("when governance adapter is deployed and module needs to be initialized", async () => {
+  context("when governance extension is deployed and module needs to be initialized", async () => {
     beforeEach(async () => {
-      governanceAdapter = await deployer.adapters.deployGovernanceAdapter(
+      governanceExtension = await deployer.extensions.deployGovernanceExtension(
         baseManagerV2.address,
         setV2Setup.governanceModule.address
       );
 
-      await baseManagerV2.connect(operator.wallet).addExtension(governanceAdapter.address);
+      await baseManagerV2.connect(operator.wallet).addExtension(governanceExtension.address);
 
-      await governanceAdapter.connect(operator.wallet).updateCallerStatus([approvedCaller.address], [true]);
+      await governanceExtension.connect(operator.wallet).updateCallerStatus([approvedCaller.address], [true]);
 
       // Transfer ownership to BaseManager
       await setToken.setManager(baseManagerV2.address);
@@ -137,7 +137,7 @@ describe("GovernanceAdapter", () => {
       });
 
       async function subject(): Promise<ContractTransaction> {
-        return await governanceAdapter.connect(subjectCaller.wallet).initialize();
+        return await governanceExtension.connect(subjectCaller.wallet).initialize();
       }
 
       it("should initialize GovernanceModule", async () => {
@@ -158,9 +158,9 @@ describe("GovernanceAdapter", () => {
       });
     });
 
-    context("when governance adapter is deployed and system fully set up", async () => {
+    context("when governance extension is deployed and system fully set up", async () => {
       beforeEach(async () => {
-        await governanceAdapter.connect(operator.wallet).initialize();
+        await governanceExtension.connect(operator.wallet).initialize();
       });
 
       describe("#delegate", async () => {
@@ -175,7 +175,7 @@ describe("GovernanceAdapter", () => {
         });
 
         async function subject(): Promise<ContractTransaction> {
-          return await governanceAdapter.connect(subjectCaller.wallet).delegate(subjectGovernanceName, subjectDelegatee);
+          return await governanceExtension.connect(subjectCaller.wallet).delegate(subjectGovernanceName, subjectDelegatee);
         }
 
         it("should correctly delegate votes", async () => {
@@ -208,7 +208,7 @@ describe("GovernanceAdapter", () => {
         });
 
         async function subject(): Promise<ContractTransaction> {
-          return await governanceAdapter.connect(subjectCaller.wallet).propose(subjectGovernanceName, subjectProposalData);
+          return await governanceExtension.connect(subjectCaller.wallet).propose(subjectGovernanceName, subjectProposalData);
         }
 
         it("should submit a proposal", async () => {
@@ -242,7 +242,7 @@ describe("GovernanceAdapter", () => {
         });
 
         async function subject(): Promise<ContractTransaction> {
-          return await governanceAdapter.connect(subjectCaller.wallet).register(subjectGovernanceName);
+          return await governanceExtension.connect(subjectCaller.wallet).register(subjectGovernanceName);
         }
 
         it("should register the SetToken for voting", async () => {
@@ -273,7 +273,7 @@ describe("GovernanceAdapter", () => {
         });
 
         async function subject(): Promise<ContractTransaction> {
-          return await governanceAdapter.connect(subjectCaller.wallet).revoke(subjectGovernanceName);
+          return await governanceExtension.connect(subjectCaller.wallet).revoke(subjectGovernanceName);
         }
 
         it("should revoke the SetToken's voting rights", async () => {
@@ -310,7 +310,7 @@ describe("GovernanceAdapter", () => {
         });
 
         async function subject(): Promise<ContractTransaction> {
-          return await governanceAdapter.connect(subjectCaller.wallet).vote(
+          return await governanceExtension.connect(subjectCaller.wallet).vote(
             subjectGovernanceName,
             subjectProposalId,
             subjectSupport,

--- a/test/adapters/streamingFeeSplitExtension.spec.ts
+++ b/test/adapters/streamingFeeSplitExtension.spec.ts
@@ -100,7 +100,7 @@ describe("StreamingFeeSplitExtension", () => {
     });
 
     async function subject(): Promise<StreamingFeeSplitExtension> {
-      return await deployer.adapters.deployStreamingFeeSplitExtension(
+      return await deployer.extensions.deployStreamingFeeSplitExtension(
         subjectManager,
         subjectStreamingFeeModule,
         subjectOperatorFeeSplit,
@@ -148,7 +148,7 @@ describe("StreamingFeeSplitExtension", () => {
     const operatorSplit: BigNumber = ether(.7);
 
     beforeEach(async () => {
-      feeExtension = await deployer.adapters.deployStreamingFeeSplitExtension(
+      feeExtension = await deployer.extensions.deployStreamingFeeSplitExtension(
         baseManagerV2.address,
         setV2Setup.streamingFeeModule.address,
         operatorSplit,

--- a/test/adapters/streamingFeeSplitExtension.spec.ts
+++ b/test/adapters/streamingFeeSplitExtension.spec.ts
@@ -3,7 +3,7 @@ import "module-alias/register";
 import { solidityKeccak256 } from "ethers/lib/utils";
 import { Address, Account } from "@utils/types";
 import { ADDRESS_ZERO, ZERO, ONE_DAY_IN_SECONDS, ONE_YEAR_IN_SECONDS } from "@utils/constants";
-import { StreamingFeeSplitExtension, BaseManager } from "@utils/contracts/index";
+import { StreamingFeeSplitExtension, BaseManagerV2 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -35,7 +35,7 @@ describe("StreamingFeeSplitExtension", () => {
   let deployer: DeployHelper;
   let setToken: SetToken;
 
-  let baseManagerV2: BaseManager;
+  let baseManagerV2: BaseManagerV2;
   let feeExtension: StreamingFeeSplitExtension;
 
   before(async () => {
@@ -58,7 +58,7 @@ describe("StreamingFeeSplitExtension", () => {
     );
 
     // Deploy BaseManager
-    baseManagerV2 = await deployer.manager.deployBaseManager(
+    baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
       methodologist.address,
@@ -155,7 +155,7 @@ describe("StreamingFeeSplitExtension", () => {
         operatorFeeRecipient.address
       );
 
-      await baseManagerV2.connect(operator.wallet).addAdapter(feeExtension.address);
+      await baseManagerV2.connect(operator.wallet).addExtension(feeExtension.address);
 
       // Transfer ownership to BaseManager
       await setToken.setManager(baseManagerV2.address);
@@ -274,18 +274,18 @@ describe("StreamingFeeSplitExtension", () => {
           await feeExtension.connect(methodologist.wallet).updateFeeRecipient(baseManagerV2.address);
 
           // Revoke extension authorization
-          await baseManagerV2.connect(operator.wallet).revokeAdapterAuthorization(
+          await baseManagerV2.connect(operator.wallet).revokeExtensionAuthorization(
             setV2Setup.streamingFeeModule.address,
             feeExtension.address
           );
 
-          await baseManagerV2.connect(methodologist.wallet).revokeAdapterAuthorization(
+          await baseManagerV2.connect(methodologist.wallet).revokeExtensionAuthorization(
             setV2Setup.streamingFeeModule.address,
             feeExtension.address
           );
 
-          // Remove adapter
-          await baseManagerV2.connect(operator.wallet).removeAdapter(feeExtension.address);
+          // Remove extension
+          await baseManagerV2.connect(operator.wallet).removeExtension(feeExtension.address);
         });
 
         it("should send residual fees to operator fee recipient and methodologist", async () => {

--- a/test/adapters/streamingFeeSplitExtension.spec.ts
+++ b/test/adapters/streamingFeeSplitExtension.spec.ts
@@ -59,8 +59,11 @@ describe("StreamingFeeSplitExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManager(
       setToken.address,
       operator.address,
-      methodologist.address
+      methodologist.address,
+      [],
+      [[]]
     );
+    await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 
     const feeRecipient = baseManagerV2.address;
     const maxStreamingFeePercentage = ether(.1);

--- a/test/adapters/streamingFeeSplitExtension.spec.ts
+++ b/test/adapters/streamingFeeSplitExtension.spec.ts
@@ -276,7 +276,6 @@ describe("StreamingFeeSplitExtension", () => {
           });
 
           it("should send correct amount of fees to operator and methodologist", async () => {
-            const preManagerBalance = await setToken.balanceOf(baseManagerV2.address);
             const feeState: any = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
             const totalSupply = await setToken.totalSupply();
 
@@ -293,9 +292,17 @@ describe("StreamingFeeSplitExtension", () => {
 
             const feeInflation = getStreamingFeeInflationAmount(expectedFeeInflation, totalSupply);
 
+            const expectedOperatorTake = preciseMul(feeInflation, operatorSplit);
+            const expectedMethodologistTake = feeInflation.sub(expectedOperatorTake);
+
+            const operatorBalance = await setToken.balanceOf(operator.address);
+            const methodologistBalance = await setToken.balanceOf(methodologist.address);
             const postManagerBalance = await setToken.balanceOf(baseManagerV2.address);
 
-            expect(postManagerBalance.sub(preManagerBalance)).to.eq(feeInflation);
+
+            expect(operatorBalance).to.eq(expectedOperatorTake);
+            expect(methodologistBalance).to.eq(expectedMethodologistTake);
+            expect(postManagerBalance).to.eq(ZERO);
           });
         });
       });
@@ -333,7 +340,6 @@ describe("StreamingFeeSplitExtension", () => {
           });
 
           it("should send correct amount of fees to operator and methodologist", async () => {
-            const preManagerBalance = await setToken.balanceOf(baseManagerV2.address);
             const feeState: any = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
             const totalSupply = await setToken.totalSupply();
 
@@ -350,9 +356,16 @@ describe("StreamingFeeSplitExtension", () => {
 
             const feeInflation = getStreamingFeeInflationAmount(expectedFeeInflation, totalSupply);
 
+            const expectedOperatorTake = preciseMul(feeInflation, operatorSplit);
+            const expectedMethodologistTake = feeInflation.sub(expectedOperatorTake);
+
+            const operatorBalance = await setToken.balanceOf(operator.address);
+            const methodologistBalance = await setToken.balanceOf(methodologist.address);
             const postManagerBalance = await setToken.balanceOf(baseManagerV2.address);
 
-            expect(postManagerBalance.sub(preManagerBalance)).to.eq(feeInflation);
+            expect(operatorBalance).to.eq(expectedOperatorTake);
+            expect(methodologistBalance).to.eq(expectedMethodologistTake);
+            expect(postManagerBalance).to.eq(ZERO);
           });
         });
       });

--- a/test/adapters/streamingFeeSplitExtension.spec.ts
+++ b/test/adapters/streamingFeeSplitExtension.spec.ts
@@ -61,9 +61,7 @@ describe("StreamingFeeSplitExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       operator.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 

--- a/test/exchangeIssuance/exchangeIssuance.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuance.spec.ts
@@ -112,7 +112,7 @@ describe("ExchangeIssuance", async () => {
     });
 
     async function subject(): Promise<ExchangeIssuance> {
-      return await deployer.adapters.deployExchangeIssuance(
+      return await deployer.extensions.deployExchangeIssuance(
         wethAddress,
         uniswapFactory.address,
         uniswapRouter.address,
@@ -282,7 +282,7 @@ describe("ExchangeIssuance", async () => {
         { value: ether(100), gasLimit: 9000000 }
       );
 
-      exchangeIssuance = await deployer.adapters.deployExchangeIssuance(
+      exchangeIssuance = await deployer.extensions.deployExchangeIssuance(
         subjectWethAddress,
         uniswapFactory.address,
         uniswapRouter.address,

--- a/test/exchangeIssuance/exchangeIssuanceV2.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceV2.spec.ts
@@ -109,7 +109,7 @@ describe("ExchangeIssuanceV2", async () => {
     });
 
     async function subject(): Promise<ExchangeIssuanceV2> {
-      return await deployer.adapters.deployExchangeIssuanceV2(
+      return await deployer.extensions.deployExchangeIssuanceV2(
         wethAddress,
         uniswapFactory.address,
         uniswapRouter.address,
@@ -279,7 +279,7 @@ describe("ExchangeIssuanceV2", async () => {
         { value: ether(100), gasLimit: 9000000 }
       );
 
-      exchangeIssuance = await deployer.adapters.deployExchangeIssuanceV2(
+      exchangeIssuance = await deployer.extensions.deployExchangeIssuanceV2(
         subjectWethAddress,
         uniswapFactory.address,
         uniswapRouter.address,

--- a/test/integration/fliIntegration.spec.ts
+++ b/test/integration/fliIntegration.spec.ts
@@ -636,9 +636,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     baseManager = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       owner.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManager.connect(methodologist.wallet).authorizeInitialization();
 

--- a/test/integration/fliIntegration.spec.ts
+++ b/test/integration/fliIntegration.spec.ts
@@ -689,7 +689,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     await flexibleLeverageStrategyExtension.updateCallerStatus([owner.address], [true]);
 
     // Add adapter
-    await baseManager.connect(owner.wallet).addAdapter(flexibleLeverageStrategyExtension.address);
+    await baseManager.connect(owner.wallet).addExtension(flexibleLeverageStrategyExtension.address);
   }
 
   async function issueFLITokens(collateralCToken: CERc20 | CEther, amount: BigNumber): Promise<void> {

--- a/test/integration/fliIntegration.spec.ts
+++ b/test/integration/fliIntegration.spec.ts
@@ -637,7 +637,10 @@ describe("FlexibleLeverageStrategyExtension", () => {
       setToken.address,
       owner.address,
       methodologist.address,
+      [],
+      [[]]
     );
+    await baseManager.connect(methodologist.wallet).authorizeInitialization();
 
     // Transfer ownership to ic manager
     await setToken.setManager(baseManager.address);

--- a/test/integration/fliIntegration.spec.ts
+++ b/test/integration/fliIntegration.spec.ts
@@ -11,7 +11,7 @@ import {
   ExchangeSettings
 } from "@utils/types";
 import { ADDRESS_ZERO, ZERO, ONE, TWO, EMPTY_BYTES, MAX_UINT_256, PRECISE_UNIT, ONE_DAY_IN_SECONDS, ONE_HOUR_IN_SECONDS } from "@utils/constants";
-import { FlexibleLeverageStrategyExtension, BaseManager, StandardTokenMock, WETH9, ChainlinkAggregatorV3Mock } from "@utils/contracts/index";
+import { FlexibleLeverageStrategyExtension, BaseManagerV2, StandardTokenMock, WETH9, ChainlinkAggregatorV3Mock } from "@utils/contracts/index";
 import { CompoundLeverageModule, SetToken } from "@utils/contracts/setV2";
 import { CEther, CERc20 } from "@utils/contracts/compound";
 import DeployHelper from "@utils/deploys";
@@ -105,7 +105,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
 
   let flexibleLeverageStrategyExtension: FlexibleLeverageStrategyExtension;
   let compoundLeverageModule: CompoundLeverageModule;
-  let baseManager: BaseManager;
+  let baseManager: BaseManagerV2;
 
   let chainlinkETH: ChainlinkAggregatorV3Mock;
   let chainlinkWBTC: ChainlinkAggregatorV3Mock;
@@ -633,7 +633,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       [fliSettings.borrowAsset.address]
     );
 
-    baseManager = await deployer.manager.deployBaseManager(
+    baseManager = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       owner.address,
       methodologist.address,

--- a/test/integration/fliIntegration.spec.ts
+++ b/test/integration/fliIntegration.spec.ts
@@ -677,7 +677,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
       incentivizedLeverageRatio: incentivizedLeverageRatio,
     };
 
-    flexibleLeverageStrategyExtension = await deployer.adapters.deployFlexibleLeverageStrategyExtension(
+    flexibleLeverageStrategyExtension = await deployer.extensions.deployFlexibleLeverageStrategyExtension(
       baseManager.address,
       strategy,
       methodology,
@@ -688,7 +688,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     );
     await flexibleLeverageStrategyExtension.updateCallerStatus([owner.address], [true]);
 
-    // Add adapter
+    // Add extension
     await baseManager.connect(owner.wallet).addExtension(flexibleLeverageStrategyExtension.address);
   }
 

--- a/test/lib/baseAdapter.spec.ts
+++ b/test/lib/baseAdapter.spec.ts
@@ -77,7 +77,7 @@ describe("BaseAdapter", () => {
 
     // Transfer ownership to BaseManager
     await setToken.setManager(baseManagerV2.address);
-    await baseManagerV2.addAdapter(baseAdapterMock.address);
+    await baseManagerV2.addExtension(baseAdapterMock.address);
 
     await baseAdapterMock.updateCallerStatus([owner.address], [true]);
   });

--- a/test/lib/baseAdapter.spec.ts
+++ b/test/lib/baseAdapter.spec.ts
@@ -68,7 +68,10 @@ describe("BaseAdapter", () => {
       setToken.address,
       owner.address,
       methodologist.address,
+      [],
+      [[]]
     );
+    await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 
     baseAdapterMock = await deployer.mocks.deployBaseAdapterMock(baseManagerV2.address);
 

--- a/test/lib/baseAdapter.spec.ts
+++ b/test/lib/baseAdapter.spec.ts
@@ -3,7 +3,7 @@ import "module-alias/register";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Account, Address, Bytes } from "@utils/types";
 import { ZERO, ADDRESS_ZERO } from "@utils/constants";
-import { BaseAdapterMock, BaseManager } from "@utils/contracts/index";
+import { BaseAdapterMock, BaseManagerV2 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import { ContractCallerMock } from "@utils/contracts/setV2";
 
@@ -29,7 +29,7 @@ describe("BaseAdapter", () => {
   let setToken: SetToken;
   let setV2Setup: SetFixture;
 
-  let baseManagerV2: BaseManager;
+  let baseManagerV2: BaseManagerV2;
   let baseAdapterMock: BaseAdapterMock;
 
   before(async () => {
@@ -64,7 +64,7 @@ describe("BaseAdapter", () => {
     await setV2Setup.streamingFeeModule.initialize(setToken.address, streamingFeeSettings);
 
     // Deploy BaseManager
-    baseManagerV2 = await deployer.manager.deployBaseManager(
+    baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       owner.address,
       methodologist.address,

--- a/test/lib/baseExtension.spec.ts
+++ b/test/lib/baseExtension.spec.ts
@@ -67,9 +67,7 @@ describe("BaseExtension", () => {
     baseManagerV2 = await deployer.manager.deployBaseManagerV2(
       setToken.address,
       owner.address,
-      methodologist.address,
-      [],
-      [[]]
+      methodologist.address
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 

--- a/test/lib/baseExtension.spec.ts
+++ b/test/lib/baseExtension.spec.ts
@@ -3,7 +3,7 @@ import "module-alias/register";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Account, Address, Bytes } from "@utils/types";
 import { ZERO, ADDRESS_ZERO } from "@utils/constants";
-import { BaseAdapterMock, BaseManagerV2 } from "@utils/contracts/index";
+import { BaseExtensionMock, BaseManagerV2 } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import { ContractCallerMock } from "@utils/contracts/setV2";
 
@@ -21,7 +21,7 @@ import { ContractTransaction } from "ethers";
 
 const expect = getWaffleExpect();
 
-describe("BaseAdapter", () => {
+describe("BaseExtension", () => {
   let owner: Account;
   let methodologist: Account;
   let otherAccount: Account;
@@ -30,7 +30,7 @@ describe("BaseAdapter", () => {
   let setV2Setup: SetFixture;
 
   let baseManagerV2: BaseManagerV2;
-  let baseAdapterMock: BaseAdapterMock;
+  let baseExtensionMock: BaseExtensionMock;
 
   before(async () => {
     [
@@ -73,13 +73,13 @@ describe("BaseAdapter", () => {
     );
     await baseManagerV2.connect(methodologist.wallet).authorizeInitialization();
 
-    baseAdapterMock = await deployer.mocks.deployBaseAdapterMock(baseManagerV2.address);
+    baseExtensionMock = await deployer.mocks.deployBaseExtensionMock(baseManagerV2.address);
 
     // Transfer ownership to BaseManager
     await setToken.setManager(baseManagerV2.address);
-    await baseManagerV2.addExtension(baseAdapterMock.address);
+    await baseManagerV2.addExtension(baseExtensionMock.address);
 
-    await baseAdapterMock.updateCallerStatus([owner.address], [true]);
+    await baseExtensionMock.updateCallerStatus([owner.address], [true]);
   });
 
   addSnapshotBeforeRestoreAfterEach();
@@ -92,7 +92,7 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).testOnlyOperator();
+      return baseExtensionMock.connect(subjectCaller.wallet).testOnlyOperator();
     }
 
     it("should succeed without revert", async () => {
@@ -118,7 +118,7 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).testOnlyMethodologist();
+      return baseExtensionMock.connect(subjectCaller.wallet).testOnlyMethodologist();
     }
 
     it("should succeed without revert", async () => {
@@ -144,7 +144,7 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).testOnlyEOA();
+      return baseExtensionMock.connect(subjectCaller.wallet).testOnlyEOA();
     }
 
     it("should succeed without revert", async () => {
@@ -161,8 +161,8 @@ describe("BaseAdapter", () => {
       beforeEach(async () => {
         contractCaller = await deployer.setV2.deployContractCallerMock();
 
-        subjectTarget = baseAdapterMock.address;
-        subjectCallData = baseAdapterMock.interface.encodeFunctionData("testOnlyEOA");
+        subjectTarget = baseExtensionMock.address;
+        subjectCallData = baseExtensionMock.interface.encodeFunctionData("testOnlyEOA");
         subjectValue = ZERO;
       });
 
@@ -188,7 +188,7 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).testOnlyAllowedCaller(subjectCaller.address);
+      return baseExtensionMock.connect(subjectCaller.wallet).testOnlyAllowedCaller(subjectCaller.address);
     }
 
     it("should succeed without revert", async () => {
@@ -206,7 +206,7 @@ describe("BaseAdapter", () => {
 
       describe("when anyoneCallable is flipped to true", async () => {
         beforeEach(async () => {
-          await baseAdapterMock.updateAnyoneCallable(true);
+          await baseExtensionMock.updateAnyoneCallable(true);
         });
 
         it("should succeed without revert", async () => {
@@ -231,7 +231,7 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).testInvokeManager(subjectModule, subjectCallData);
+      return baseExtensionMock.connect(subjectCaller.wallet).testInvokeManager(subjectModule, subjectCallData);
     }
 
     it("should call updateFeeRecipient on the streaming fee module from the SetToken", async () => {
@@ -255,7 +255,7 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.testInvokeManagerTransfer(
+      return baseExtensionMock.testInvokeManagerTransfer(
         subjectToken,
         subjectDestination,
         subjectAmount
@@ -288,17 +288,17 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).updateCallerStatus(subjectFunctionCallers, subjectStatuses);
+      return baseExtensionMock.connect(subjectCaller.wallet).updateCallerStatus(subjectFunctionCallers, subjectStatuses);
     }
 
     it("should update the callAllowList", async () => {
       await subject();
-      const callerStatus = await baseAdapterMock.callAllowList(subjectFunctionCallers[0]);
+      const callerStatus = await baseExtensionMock.callAllowList(subjectFunctionCallers[0]);
       expect(callerStatus).to.be.true;
     });
 
     it("should emit CallerStatusUpdated event", async () => {
-      await expect(subject()).to.emit(baseAdapterMock, "CallerStatusUpdated").withArgs(
+      await expect(subject()).to.emit(baseExtensionMock, "CallerStatusUpdated").withArgs(
         subjectFunctionCallers[0],
         subjectStatuses[0]
       );
@@ -325,17 +325,17 @@ describe("BaseAdapter", () => {
     });
 
     async function subject(): Promise<ContractTransaction> {
-      return baseAdapterMock.connect(subjectCaller.wallet).updateAnyoneCallable(subjectStatus);
+      return baseExtensionMock.connect(subjectCaller.wallet).updateAnyoneCallable(subjectStatus);
     }
 
     it("should update the anyoneCallable boolean", async () => {
       await subject();
-      const callerStatus = await baseAdapterMock.anyoneCallable();
+      const callerStatus = await baseExtensionMock.anyoneCallable();
       expect(callerStatus).to.be.true;
     });
 
     it("should emit AnyoneCallableUpdated event", async () => {
-      await expect(subject()).to.emit(baseAdapterMock, "AnyoneCallableUpdated").withArgs(
+      await expect(subject()).to.emit(baseExtensionMock, "AnyoneCallableUpdated").withArgs(
         subjectStatus
       );
     });

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -16,13 +16,10 @@ import {
 } from "@utils/index";
 import { SetFixture } from "@utils/fixtures";
 
-import { solidityKeccak256 } from "ethers/lib/utils";
-import { ContractTransaction } from "ethers";
-
 const expect = getWaffleExpect();
 
 describe("BaseManager", () => {
-  let operator: Account;
+  let owner: Account;
   let methodologist: Account;
   let otherAccount: Account;
   let newManager: Account;
@@ -34,40 +31,28 @@ describe("BaseManager", () => {
   let baseManager: BaseManager;
   let baseAdapter: BaseAdapterMock;
 
-  async function validateMutualUprade(txHash: ContractTransaction, caller: Address) {
-    const expectedHash = solidityKeccak256(["bytes", "address"], [txHash.data, caller]);
-    const isLogged = await baseManager.mutualUpgrades(expectedHash);
-    expect(isLogged).to.be.true;
-  }
-
   before(async () => {
     [
-      operator,
+      owner,
       otherAccount,
       newManager,
       methodologist,
     ] = await getAccounts();
 
-    deployer = new DeployHelper(operator.wallet);
+    deployer = new DeployHelper(owner.wallet);
 
-    setV2Setup = getSetFixture(operator.address);
+    setV2Setup = getSetFixture(owner.address);
     await setV2Setup.initialize();
 
     setToken = await setV2Setup.createSetToken(
       [setV2Setup.dai.address],
       [ether(1)],
-      [
-        setV2Setup.issuanceModule.address,
-        setV2Setup.streamingFeeModule.address,
-        setV2Setup.governanceModule.address,
-      ]
+      [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
     );
 
     // Initialize modules
     await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
-    await setV2Setup.governanceModule.initialize(setToken.address);
-
-    const feeRecipient = operator.address;
+    const feeRecipient = owner.address;
     const maxStreamingFeePercentage = ether(.1);
     const streamingFeePercentage = ether(.02);
     const streamingFeeSettings = {
@@ -81,13 +66,11 @@ describe("BaseManager", () => {
     // Deploy BaseManager
     baseManager = await deployer.manager.deployBaseManager(
       setToken.address,
-      operator.address,
+      owner.address,
       methodologist.address,
-      [],
-      [[]]
     );
 
-    // Transfer operatorship to BaseManager
+    // Transfer ownership to BaseManager
     await setToken.setManager(baseManager.address);
 
     baseAdapter = await deployer.mocks.deployBaseAdapterMock(baseManager.address);
@@ -97,25 +80,13 @@ describe("BaseManager", () => {
 
   describe("#constructor", async () => {
     let subjectSetToken: Address;
-    let subjectAdapter: Address;
-    let subjectModule: Address;
-    let subjectAdditionalModule: Address;
-    let subjectAdditionalAdapter: Address;
     let subjectOperator: Address;
     let subjectMethodologist: Address;
-    let subjectProtectedModules: Address[];
-    let subjectAuthorizedAdapters: Address[][];
 
     beforeEach(async () => {
       subjectSetToken = setToken.address;
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdditionalModule = setV2Setup.issuanceModule.address;
-      subjectAdapter = baseAdapter.address;
-      subjectAdditionalAdapter = ADDRESS_ZERO; // Deploy as needed
-      subjectOperator = operator.address;
+      subjectOperator = owner.address;
       subjectMethodologist = methodologist.address;
-      subjectProtectedModules = [subjectModule];
-      subjectAuthorizedAdapters = [[]];
     });
 
     async function subject(): Promise<BaseManager> {
@@ -123,8 +94,6 @@ describe("BaseManager", () => {
         subjectSetToken,
         subjectOperator,
         subjectMethodologist,
-        subjectProtectedModules,
-        subjectAuthorizedAdapters
       );
     }
 
@@ -148,171 +117,6 @@ describe("BaseManager", () => {
       const actualMethodologist = await retrievedICManager.methodologist();
       expect (actualMethodologist).to.eq(subjectMethodologist);
     });
-
-    it("should not be initialized by default", async () => {
-      const retrievedICManager = await subject();
-
-      const initialized = await retrievedICManager.initialized();
-      expect(initialized).to.be.false;
-    });
-
-    describe("protectedModules: single, no extensions", () => {
-      beforeEach(() => {
-        subjectProtectedModules = [subjectModule];
-      });
-
-      // This test is borked... module initialized in before block..
-      it("should add module to setToken", async () => {
-        await subject();
-
-        const initialized = await setToken.isInitializedModule(subjectModule);
-
-        expect(initialized).to.be.true;
-      });
-
-      it("should protect the module", async () => {
-        const retrievedICManager = await subject();
-
-        const isProtected = await retrievedICManager.protectedModules(subjectModule);
-        expect(isProtected).to.be.true;
-      });
-
-      it("should be added to the protectedModules list", async () => {
-        const retrievedICManager = await subject();
-
-        const protectedModules = await retrievedICManager.getProtectedModules();
-        expect(protectedModules.includes(subjectModule)).to.be.true;
-      });
-    });
-
-    describe("protectedModules: single, with multiple extension", () => {
-      beforeEach(async () => {
-        subjectAdditionalAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
-        subjectProtectedModules = [subjectModule];
-        subjectAuthorizedAdapters = [[subjectAdapter, subjectAdditionalAdapter]];
-      });
-
-      it("should protect the module", async () => {
-        const retrievedICManager = await subject();
-
-        const isProtected = await retrievedICManager.protectedModules(subjectModule);
-        expect(isProtected).to.be.true;
-      });
-
-      it("should add the extensions", async () => {
-        const retrievedICManager = await subject();
-
-        const isSubjectAdapter = await retrievedICManager.isAdapter(subjectAdapter);
-        const isSubjectAdditionalAdapter = await retrievedICManager.isAdapter(subjectAdditionalAdapter);
-
-        expect(isSubjectAdapter).to.be.true;
-        expect(isSubjectAdditionalAdapter).to.be.true;
-      });
-
-      it("should authorize the extensions for the module", async () => {
-        const retrievedICManager = await subject();
-
-        const isAuthorizedSubjectAdapter = await retrievedICManager
-          .isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        const isAuthorizedSubjectAdditionalAdapter = await retrievedICManager
-          .isAuthorizedAdapter(subjectModule, subjectAdditionalAdapter);
-
-        expect(isAuthorizedSubjectAdapter).to.be.true;
-        expect(isAuthorizedSubjectAdditionalAdapter).to.be.true;
-      });
-    });
-
-    describe("protectedModules: multiple, with extensions", () => {
-      beforeEach(async () => {
-        subjectAdditionalAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
-        subjectProtectedModules = [subjectModule, subjectAdditionalModule];
-        subjectAuthorizedAdapters = [ [subjectAdapter], [subjectAdditionalAdapter] ];
-      });
-
-      it("should protect the module", async () => {
-        const retrievedICManager = await subject();
-
-        const isProtectedSubjectModule = await retrievedICManager
-          .protectedModules(subjectModule);
-
-        const isProtectedSubjectAdditionalModule = await retrievedICManager
-          .protectedModules(subjectAdditionalModule);
-
-        expect(isProtectedSubjectModule).to.be.true;
-        expect(isProtectedSubjectAdditionalModule).to.be.true;
-      });
-
-      it("should add the adapters", async () => {
-        const retrievedICManager = await subject();
-
-        const isSubjectAdapter = await retrievedICManager.isAdapter(subjectAdapter);
-        const isSubjectAdditionalAdapter = await retrievedICManager.isAdapter(subjectAdditionalAdapter);
-
-        expect(isSubjectAdapter).to.be.true;
-        expect(isSubjectAdditionalAdapter).to.be.true;
-      });
-
-      it("should authorize the adapters correctly", async () => {
-        const retrievedICManager = await subject();
-
-        const isAuthorizedSubjectAdapter = await retrievedICManager
-          .isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        const isAuthorizedSubjectAdditionalAdapter = await retrievedICManager
-          .isAuthorizedAdapter(subjectAdditionalModule, subjectAdditionalAdapter);
-
-        const transposedAdapterIsAuthorized = await retrievedICManager
-          .isAuthorizedAdapter(subjectModule, subjectAdditionalAdapter);
-
-        expect(isAuthorizedSubjectAdapter).to.be.true;
-        expect(isAuthorizedSubjectAdditionalAdapter).to.be.true;
-        expect(transposedAdapterIsAuthorized).to.be.false;
-      });
-    });
-  });
-
-  describe("#authorizeInitialization", () => {
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectCaller = methodologist;
-    });
-
-    async function subject(): Promise<any> {
-      return baseManager.connect(subjectCaller.wallet).authorizeInitialization();
-    }
-
-    it("sets initialized to true", async() => {
-      const defaultInitialized = await baseManager.initialized();
-
-      await subject();
-
-      const updatedInitialized = await baseManager.initialized();
-
-      expect(defaultInitialized).to.be.false;
-      expect(updatedInitialized).to.be.true;
-    });
-
-    describe("when the caller is not the methodologist", async () => {
-      beforeEach(async () => {
-        subjectCaller = await getRandomAccount();
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be methodologist");
-      });
-    });
-
-    describe("when the manager is already initialized", async () => {
-      beforeEach(async () => {
-        await subject();
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Initialization authorized");
-      });
-    });
   });
 
   describe("#setManager", async () => {
@@ -321,26 +125,18 @@ describe("BaseManager", () => {
 
     beforeEach(async () => {
       subjectNewManager = newManager.address;
-      subjectCaller = operator;
+      subjectCaller = owner;
     });
 
-    async function subject(caller: Account): Promise<any> {
-      return baseManager.connect(caller.wallet).setManager(subjectNewManager);
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).setManager(subjectNewManager);
     }
 
     it("should change the manager address", async () => {
-      await subject(operator);
-      await subject(methodologist);
+      await subject();
       const manager = await setToken.manager();
 
       expect(manager).to.eq(newManager.address);
-    });
-
-    describe("when a single mutual upgrade party calls", () => {
-      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
-        const txHash = await subject(operator);
-        await validateMutualUprade(txHash, operator.address);
-      });
     });
 
     describe("when passed manager is the zero address", async () => {
@@ -349,31 +145,28 @@ describe("BaseManager", () => {
       });
 
       it("should revert", async () => {
-        await subject(operator);
-        await expect(subject(methodologist)).to.be.revertedWith("Zero address not valid");
+        await expect(subject()).to.be.revertedWith("Zero address not valid");
       });
     });
 
-    describe("when the caller is not the operator or the methodologist", async () => {
+    describe("when the caller is not the operator", async () => {
       beforeEach(async () => {
-        subjectCaller = await getRandomAccount();
+        subjectCaller = methodologist;
       });
 
       it("should revert", async () => {
-        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized address");
+        await expect(subject()).to.be.revertedWith("Must be operator");
       });
     });
   });
 
   describe("#addAdapter", async () => {
-    let subjectModule: Address;
     let subjectAdapter: Address;
     let subjectCaller: Account;
 
     beforeEach(async () => {
-      subjectModule = setV2Setup.streamingFeeModule.address;
       subjectAdapter = baseAdapter.address;
-      subjectCaller = operator;
+      subjectCaller = owner;
     });
 
     async function subject(): Promise<any> {
@@ -418,18 +211,6 @@ describe("BaseManager", () => {
       });
     });
 
-    describe("when an emergency is in progress", async () => {
-      beforeEach(async () => {
-        baseManager.connect(operator.wallet);
-        await baseManager.protectModule(subjectModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectModule);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Upgrades paused by emergency");
-      });
-    });
-
     describe("when the caller is not the operator", async () => {
       beforeEach(async () => {
         subjectCaller = methodologist;
@@ -442,20 +223,14 @@ describe("BaseManager", () => {
   });
 
   describe("#removeAdapter", async () => {
-    let subjectModule: Address;
-    let subjectAdditionalModule: Address;
     let subjectAdapter: Address;
-    let subjectAdditionalAdapter: Address;
     let subjectCaller: Account;
 
     beforeEach(async () => {
-      await baseManager.connect(operator.wallet).addAdapter(baseAdapter.address);
+      await baseManager.connect(owner.wallet).addAdapter(baseAdapter.address);
 
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdditionalModule = setV2Setup.issuanceModule.address;
       subjectAdapter = baseAdapter.address;
-      subjectAdditionalAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
-      subjectCaller = operator;
+      subjectCaller = owner;
     });
 
     async function subject(): Promise<any> {
@@ -499,269 +274,6 @@ describe("BaseManager", () => {
         await expect(subject()).to.be.revertedWith("Must be operator");
       });
     });
-
-    describe("when the adapter is authorized for a protected module", () => {
-      beforeEach(() => {
-        baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should revert", async() => {
-        await expect(subject()).to.be.revertedWith("Adapter used by protected module");
-      });
-    });
-
-    // This test for the coverage report - hits an alternate branch condition the authorized
-    // adapters search method....
-    describe("when multiple adaptersa are authorized for multiple protected modules", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).protectModule(subjectAdditionalModule, [subjectAdditionalAdapter]);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should revert", async() => {
-        await expect(subject()).to.be.revertedWith("Adapter used by protected module");
-      });
-    });
-  });
-
-  describe("#authorizeAdapter", () => {
-    let subjectModule: Address;
-    let subjectAdapter: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectCaller = operator;
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdapter = baseAdapter.address;
-    });
-
-    async function subject(caller: Account): Promise<any> {
-      return baseManager.connect(caller.wallet).authorizeAdapter(subjectModule, subjectAdapter);
-    }
-
-    describe("when adapter is not authorized and already added", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
-      });
-
-      it("should authorize the adapter", async () => {
-        const initialAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialAuthorization).to.be.false;
-        expect(finalAuthorization).to.be.true;
-      });
-
-      it("should emit the correct AdapterAuthorized event", async () => {
-        await subject(operator);
-
-        await expect(subject(methodologist)).to
-          .emit(baseManager, "AdapterAuthorized")
-          .withArgs(subjectModule, subjectAdapter);
-      });
-    });
-
-    describe("when adapter is not already added to the manager", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
-      });
-
-      it("should add and authorize the adapter", async () => {
-        const initialIsAdapter = await baseManager.isAdapter(subjectAdapter);
-        const initialAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalIsAdapter = await baseManager.isAdapter(subjectAdapter);
-        const finalAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialIsAdapter).to.be.false;
-        expect(initialAuthorization).to.be.false;
-        expect(finalIsAdapter).to.be.true;
-        expect(finalAuthorization).to.be.true;
-      });
-    });
-
-    describe("when the adapter is already authorized for target module", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should revert", async () => {
-        await subject(operator);
-        await expect(subject(methodologist)).to.be.revertedWith("Adapter already authorized");
-      });
-    });
-
-    describe("when target module is not protected", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-      });
-
-      it("should revert", async () => {
-        const isProtected = await baseManager.protectedModules(subjectModule);
-
-        await subject(operator);
-
-        await expect(isProtected).to.be.false;
-        await expect(subject(methodologist)).to.be.revertedWith("Module not protected");
-      });
-    });
-
-    describe("when a single mutual upgrade party calls", () => {
-      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
-        const txHash = await subject(operator);
-        await validateMutualUprade(txHash, operator.address);
-      });
-    });
-
-    describe("when the caller is not the operator or methodologist", async () => {
-      beforeEach(async () => {
-        subjectCaller = await getRandomAccount();
-      });
-
-      it("should revert", async () => {
-        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
-      });
-    });
-  });
-
-  describe("#revokeAdapterAuthorization", () => {
-    let subjectModule: Address;
-    let subjectAdditionalModule: Address;
-    let subjectAdapter: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectCaller = operator;
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdditionalModule = setV2Setup.issuanceModule.address;
-      subjectAdapter = baseAdapter.address;
-    });
-
-    async function subject(caller: Account): Promise<any> {
-      return baseManager.connect(caller.wallet).revokeAdapterAuthorization(subjectModule, subjectAdapter);
-    }
-
-    describe("when adapter is authorized", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should revoke adapter authorization", async () => {
-        const initialAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialAuthorization).to.be.true;
-        expect(finalAuthorization).to.be.false;
-      });
-
-      it("should emit the correct AdapterAuthorizationRevoked event", async () => {
-        await subject(operator);
-
-        await expect(subject(methodologist)).to
-          .emit(baseManager, "AdapterAuthorizationRevoked")
-          .withArgs(subjectModule, subjectAdapter);
-      });
-    });
-
-    describe("when an adapter is shared by protected modules", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-        await baseManager.connect(operator.wallet).protectModule(subjectAdditionalModule, [subjectAdapter]);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should only revoke authorization for the specified module", async () => {
-        const initialAuth = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-        const initialAdditionalAuth = await baseManager.isAuthorizedAdapter(subjectAdditionalModule, subjectAdapter);
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalAuth = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-        const finalAdditionalAuth = await baseManager.isAuthorizedAdapter(subjectAdditionalModule, subjectAdapter);
-
-        expect(initialAuth).to.be.true;
-        expect(initialAdditionalAuth).to.be.true;
-        expect(finalAuth).to.be.false;
-        expect(finalAdditionalAuth).to.be.true;
-      });
-    });
-
-    describe("when adapter is not added to the manager", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
-      });
-
-      it("should revert", async () => {
-        const initialAdapterStatus = await baseManager.connect(operator.wallet).isAdapter(subjectAdapter);
-
-        await subject(operator);
-
-        await expect(initialAdapterStatus).to.be.false;
-        await expect(subject(methodologist)).to.be.revertedWith("Adapter does not exist");
-      });
-    });
-
-    describe("when the adapter is not authorized for target module", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
-      });
-
-      it("should revert", async () => {
-        const initialAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject(operator);
-        await expect(initialAuthorization).to.be.false;
-        await expect(subject(methodologist)).to.be.revertedWith("Adapter not authorized");
-      });
-    });
-
-    describe("when target module is not protected", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-      });
-
-      it("should revert", async () => {
-        const isProtected = await baseManager.protectedModules(subjectModule);
-
-        await subject(operator);
-
-        await expect(isProtected).to.be.false;
-        await expect(subject(methodologist)).to.be.revertedWith("Module not protected");
-      });
-    });
-
-    describe("when a single mutual upgrade party calls", () => {
-      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
-        const txHash = await subject(operator);
-        await validateMutualUprade(txHash, operator.address);
-      });
-    });
-
-    describe("when the caller is not the operator or methodologist", async () => {
-      beforeEach(async () => {
-        subjectCaller = await getRandomAccount();
-      });
-
-      it("should revert", async () => {
-        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
-      });
-    });
   });
 
   describe("#addModule", async () => {
@@ -772,7 +284,7 @@ describe("BaseManager", () => {
       await setV2Setup.controller.addModule(otherAccount.address);
 
       subjectModule = otherAccount.address;
-      subjectCaller = operator;
+      subjectCaller = owner;
     });
 
     async function subject(): Promise<any> {
@@ -785,754 +297,25 @@ describe("BaseManager", () => {
       expect(isModule).to.eq(true);
     });
 
-    describe("when an emergency is in progress", async () => {
-      beforeEach(async () => {
-        subjectModule = setV2Setup.streamingFeeModule.address;
-        await baseManager.protectModule(subjectModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectModule);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Upgrades paused by emergency");
-      });
-    });
-
     describe("when the caller is not the operator", async () => {
-      beforeEach(async () => {
-        subjectCaller = methodologist;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be operator");
-      });
-    });
-  });
-
-  describe("#emergencyRemoveProtectedModule", () => {
-    let subjectModule: Address;
-    let subjectAdditionalModule: Address;
-    let subjectAdapter: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectCaller = operator;
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdditionalModule = setV2Setup.governanceModule.address; // Removable
-      subjectAdapter = baseAdapter.address;
-    });
-
-    async function subject(): Promise<any> {
-      return baseManager.connect(subjectCaller.wallet).emergencyRemoveProtectedModule(subjectModule);
-    }
-
-    describe("when module is protected", async () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should remove the module from the set token", async () => {
-        await subject();
-        const isModule = await setToken.isInitializedModule(subjectModule);
-        expect(isModule).to.eq(false);
-      });
-
-      it("should unprotect the module", async () => {
-        await subject();
-        const isProtected = await baseManager.protectedModules(subjectModule);
-        expect(isProtected).to.be.false;
-      });
-
-      it("should clear the protected modules authorized extension registries", async () => {
-        const initialAuthorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectModule);
-        const initialIsAuthorized = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject();
-
-        const finalAuthorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectModule);
-        const finalIsAuthorized = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialAuthorizedAdaptersList.length).equals(1);
-        expect(initialIsAuthorized).to.be.true;
-        expect(finalAuthorizedAdaptersList.length).equals(0);
-        expect(finalIsAuthorized).to.be.false;
-      });
-
-      it("should not preserve any settings if same module is removed and restored", async () => {
-        await subject();
-
-        await baseManager.connect(methodologist.wallet).resolveEmergency();
-        await baseManager.connect(operator.wallet).addModule(subjectModule);
-
-        // Invoke initialize on streamingFeeModule
-        const feeRecipient = operator.address;
-        const maxStreamingFeePercentage = ether(.1);
-        const streamingFeePercentage = ether(.02);
-        const streamingFeeSettings = {
-          feeRecipient,
-          maxStreamingFeePercentage,
-          streamingFeePercentage,
-          lastStreamingFeeTimestamp: ZERO,
-        };
-
-        const initializeData = setV2Setup
-          .streamingFeeModule
-          .interface
-          .encodeFunctionData("initialize", [setToken.address, streamingFeeSettings]);
-
-        await baseManager.connect(methodologist.wallet).authorizeInitialization();
-        await baseAdapter.interactManager(subjectModule, initializeData);
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
-
-        const authorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectModule);
-        const isAuthorized = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(authorizedAdaptersList.length).equals(0);
-        expect(isAuthorized).to.be.false;
-      });
-
-      it("should increment the emergencies counter", async () => {
-        const initialEmergencies = await baseManager.emergencies();
-
-        await subject();
-
-        const finalEmergencies = await baseManager.emergencies();
-
-        expect(initialEmergencies.toNumber()).equals(0);
-        expect(finalEmergencies.toNumber()).equals(1);
-      });
-
-      it("should emit the correct EmergencyRemovedProtectedModule event", async () => {
-        await expect(subject()).to
-          .emit(baseManager, "EmergencyRemovedProtectedModule")
-          .withArgs(subjectModule);
-      });
-    });
-
-    describe("when an emergency is already in progress", async () => {
-      beforeEach(async () => {
-        baseManager.connect(operator.wallet);
-
-        await baseManager.protectModule(subjectModule, []);
-        await baseManager.protectModule(subjectAdditionalModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectAdditionalModule);
-      });
-
-      it("should increment the emergencies counter", async () => {
-        const initialEmergencies = await baseManager.emergencies();
-
-        await subject();
-
-        const finalEmergencies = await baseManager.emergencies();
-
-        expect(initialEmergencies.toNumber()).equals(1);
-        expect(finalEmergencies.toNumber()).equals(2);
-      });
-    });
-
-    describe("when module is not protected", () => {
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Module not protected");
-      });
-    });
-
-    describe("when the caller is not the operator", async () => {
-      beforeEach(async () => {
-        subjectCaller = methodologist;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be operator");
-      });
-    });
-  });
-
-  describe("#protectModule", () => {
-    let subjectModule: Address;
-    let subjectAdditionalModule: Address;
-    let subjectAdapter: Address;
-    let subjectAuthorizedAdapters: Address[];
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectCaller = operator;
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdapter = baseAdapter.address;
-      subjectAdditionalModule = setV2Setup.governanceModule.address; // Removable
-      subjectAuthorizedAdapters = [];
-    });
-
-    async function subject(): Promise<any> {
-      return baseManager
-        .connect(subjectCaller.wallet)
-        .protectModule(subjectModule, subjectAuthorizedAdapters);
-    }
-
-    describe("when module already added, no extensions", () => {
-      it("should protect the module", async () => {
-        const initialIsProtected = await baseManager.protectedModules(subjectModule);
-        const initialProtectedModulesList = await baseManager.getProtectedModules();
-
-        await subject();
-
-        const finalIsProtected = await baseManager.protectedModules(subjectModule);
-        const finalProtectedModulesList = await baseManager.getProtectedModules();
-
-        expect(initialIsProtected).to.be.false;
-        expect(finalIsProtected).to.be.true;
-        expect(initialProtectedModulesList.length).equals(0);
-        expect(finalProtectedModulesList.length).equals(1);
-      });
-    });
-
-    describe("when module already added, with non-added adapter", () => {
-      beforeEach(() => {
-        subjectAuthorizedAdapters = [subjectAdapter];
-      });
-      it("should add and authorize the adapter", async () => {
-        const initialIsAdapter = await baseManager.isAdapter(subjectAdapter);
-        const initialIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject();
-
-        const finalIsAdapter = await baseManager.isAdapter(subjectAdapter);
-        const finalIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialIsAdapter).to.be.false;
-        expect(finalIsAdapter).to.be.true;
-        expect(initialIsAuthorizedAdapter).to.be.false;
-        expect(finalIsAuthorizedAdapter).to.be.true;
-      });
-
-      // With adapters...
-      it("should emit the correct ModuleProtected event", async () => {
-        await expect(subject()).to
-          .emit(baseManager, "ModuleProtected")
-          .withArgs(subjectModule, subjectAuthorizedAdapters);
-      });
-    });
-
-    describe("when module and adapter already added", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
-        subjectAuthorizedAdapters = [subjectAdapter];
-      });
-
-      it("should authorize the adapter", async () => {
-        const initialIsAdapter = await baseManager.isAdapter(subjectAdapter);
-        const initialIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject();
-
-        const finalIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialIsAdapter).to.be.true;
-        expect(initialIsAuthorizedAdapter).to.be.false;
-        expect(finalIsAuthorizedAdapter).to.be.true;
-      });
-    });
-
-    describe("when module not added", () => {
-      beforeEach(async () => {
-        await baseManager.removeModule(subjectModule);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Module not added yet");
-      });
-    });
-
-    describe("when module already protected", () => {
-      beforeEach(async () => {
-        await baseManager.protectModule(subjectModule, []);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Module already protected");
-      });
-    });
-
-    describe("when an emergency is in progress", async () => {
-      beforeEach(async () => {
-        await baseManager.protectModule(subjectAdditionalModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectAdditionalModule);
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Upgrades paused by emergency");
-      });
-    });
-
-    describe("when the caller is not the operator", async () => {
-      beforeEach(async () => {
-        subjectCaller = methodologist;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be operator");
-      });
-    });
-  });
-
-  describe("#unProtectModule", () => {
-    let subjectModule: Address;
-    let subjectAdapter: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectCaller = methodologist;
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdapter = baseAdapter.address;
-    });
-
-    async function subject(): Promise<any> {
-      return baseManager.connect(subjectCaller.wallet).unProtectModule(subjectModule);
-    }
-
-    describe("when module is protected", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should *not* remove the module from the set token", async () => {
-        await subject();
-        const isModule = await setToken.isInitializedModule(subjectModule);
-        expect(isModule).to.be.true;
-      });
-
-      it("should unprotect the module", async () => {
-        await subject();
-        const isProtected = await baseManager.protectedModules(subjectModule);
-        expect(isProtected).to.be.false;
-      });
-
-      it("should clear the protected modules authorized extension registries", async () => {
-        const initialAuthorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectModule);
-        const initialIsAuthorized = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        await subject();
-
-        const finalAuthorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectModule);
-        const finalIsAuthorized = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(initialAuthorizedAdaptersList.length).equals(1);
-        expect(initialIsAuthorized).to.be.true;
-        expect(finalAuthorizedAdaptersList.length).equals(0);
-        expect(finalIsAuthorized).to.be.false;
-      });
-
-      it("should not preserve any settings if same module is removed and restored", async () => {
-        await subject();
-
-        // Restore without adapter
-        await baseManager.protectModule(subjectModule, []);
-
-        const authorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectModule);
-        const isAuthorized = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
-
-        expect(authorizedAdaptersList.length).equals(0);
-        expect(isAuthorized).to.be.false;
-      });
-
-      it("should emit the correct ModuleUnprotected event", async () => {
-        await expect(subject()).to
-          .emit(baseManager, "ModuleUnprotected")
-          .withArgs(subjectModule);
-      });
-    });
-
-    describe("when module is not protected", () => {
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Module not protected");
-      });
-    });
-
-    describe("when the caller is not the methodologist", async () => {
-      beforeEach(async () => {
-        subjectCaller = operator;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be methodologist");
-      });
-    });
-  });
-
-  describe("#replaceProtectedModule", () => {
-    let subjectOldModule: Address;
-    let subjectNewModule: Address;
-    let subjectOldAdapter: Address;
-    let subjectNewAdapter: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      await setV2Setup.controller.addModule(otherAccount.address);
-
-      subjectCaller = operator;
-      subjectOldModule = setV2Setup.streamingFeeModule.address;
-      subjectNewModule = otherAccount.address;
-      subjectOldAdapter = baseAdapter.address;
-      subjectNewAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
-    });
-
-    async function subject(caller: Account): Promise<any> {
-      return baseManager
-        .connect(caller.wallet)
-        .replaceProtectedModule(subjectOldModule, subjectNewModule, [subjectNewAdapter]);
-    }
-
-    describe("when old module is protected", () => {
-      beforeEach(async () => {
-        await baseManager.connect(operator.wallet).protectModule(subjectOldModule, [subjectOldAdapter]);
-      });
-
-      describe("when new module is not added", () => {
-        it("should add new module to setToken", async () => {
-          const initialModuleAdded = await setToken.isPendingModule(subjectNewModule);
-
-          await subject(operator);
-          await subject(methodologist);
-
-          const finalModuleAdded = await setToken.isPendingModule(subjectNewModule);
-
-          expect(initialModuleAdded).to.be.false;
-          expect(finalModuleAdded).to.be.true;
-        });
-
-        it("should remove old module from setToken", async () => {
-          const initialModuleAdded = await setToken.isInitializedModule(subjectOldModule);
-
-          await subject(operator);
-          await subject(methodologist);
-
-          const finalModuleAdded = await setToken.isInitializedModule(subjectOldModule);
-
-          expect(initialModuleAdded).to.be.true;
-          expect(finalModuleAdded).to.be.false;
-        });
-
-        it("should protect the module", async () => {
-          const initialIsProtected = await baseManager.protectedModules(subjectNewModule);
-          const initialProtectedModulesList = await baseManager.getProtectedModules();
-
-          await subject(operator);
-          await subject(methodologist);
-
-          const finalIsProtected = await baseManager.protectedModules(subjectNewModule);
-          const finalProtectedModulesList = await baseManager.getProtectedModules();
-
-          expect(initialIsProtected).to.be.false;
-          expect(finalIsProtected).to.be.true;
-          expect(initialProtectedModulesList[0]).equals(subjectOldModule);
-          expect(finalProtectedModulesList[0]).equals(subjectNewModule);
-        });
-
-        it("should unprotect the old module", async () => {
-          await subject(operator);
-          await subject(methodologist);
-
-          const isProtected = await baseManager.protectedModules(subjectOldModule);
-          expect(isProtected).to.be.false;
-        });
-
-        it("should clear the old modules authorized adapter registries", async () => {
-          const initialAuthorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectOldModule);
-          const initialIsAuthorized = await baseManager.isAuthorizedAdapter(subjectOldModule, subjectOldAdapter);
-
-          await subject(operator);
-          await subject(methodologist);
-
-          const finalAuthorizedAdaptersList = await baseManager.getAuthorizedAdapters(subjectOldModule);
-          const finalIsAuthorized = await baseManager.isAuthorizedAdapter(subjectOldModule, subjectOldAdapter);
-
-          expect(initialAuthorizedAdaptersList.length).equals(1);
-          expect(initialIsAuthorized).to.be.true;
-          expect(finalAuthorizedAdaptersList.length).equals(0);
-          expect(finalIsAuthorized).to.be.false;
-        });
-
-        it("should add and authorize the new module adapter", async () => {
-          const initialIsAdapter = await baseManager.isAdapter(subjectNewAdapter);
-          const initialIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(
-            subjectNewModule, subjectNewAdapter
-          );
-
-          await subject(operator);
-          await subject(methodologist);
-
-          const finalIsAdapter = await baseManager.isAdapter(subjectNewAdapter);
-          const finalIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(
-            subjectNewModule,
-            subjectNewAdapter
-          );
-
-          expect(initialIsAdapter).to.be.false;
-          expect(finalIsAdapter).to.be.true;
-          expect(initialIsAuthorizedAdapter).to.be.false;
-          expect(finalIsAuthorizedAdapter).to.be.true;
-        });
-
-        it("should emit the correct ReplacedProtectedModule event", async () => {
-          await subject(operator);
-
-          await expect(subject(methodologist)).to
-            .emit(baseManager, "ReplacedProtectedModule")
-            .withArgs(subjectOldModule, subjectNewModule, [subjectNewAdapter]);
-        });
-      });
-
-      describe("when the new module is already added", async () => {
-        beforeEach(async () => {
-          await baseManager.addModule(subjectNewModule);
-        });
-
-        it("should revert", async () => {
-          await subject(operator);
-          await expect(subject(methodologist)).to.be.revertedWith("Module must not be added");
-        });
-      });
-    });
-
-    describe("when old module is not protected", () => {
-      it("should revert", async () => {
-        await subject(operator);
-        await expect(subject(methodologist)).to.be.revertedWith("Module not protected");
-      });
-    });
-
-    describe("when a single mutual upgrade party calls", () => {
-      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
-        const txHash = await subject(operator);
-        await validateMutualUprade(txHash, operator.address);
-      });
-    });
-
-    describe("when the caller is not the operator or methodologist", async () => {
       beforeEach(async () => {
         subjectCaller = await getRandomAccount();
       });
 
       it("should revert", async () => {
-        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
-      });
-    });
-  });
-
-  describe("#emergencyReplaceProtectedModule", () => {
-    let subjectOldModule: Address;
-    let subjectAdditionalOldModule: Address;
-    let subjectNewModule: Address;
-    let subjectNewAdapter: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      await setV2Setup.controller.addModule(otherAccount.address);
-
-      subjectCaller = operator;
-      subjectOldModule = setV2Setup.streamingFeeModule.address;
-      subjectAdditionalOldModule = setV2Setup.governanceModule.address; // Removable
-      subjectNewModule = otherAccount.address;
-      subjectNewAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
-    });
-
-    async function subject(caller: Account): Promise<any> {
-      return baseManager
-        .connect(caller.wallet)
-        .emergencyReplaceProtectedModule(subjectNewModule, [subjectNewAdapter]);
-    }
-
-    describe("when new module is not added", () => {
-      beforeEach(async () => {
-        // Trigger emergency
-        baseManager.connect(operator.wallet);
-        await baseManager.protectModule(subjectOldModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectOldModule);
-      });
-
-      it("should add module to setToken", async () => {
-        const initialModuleAdded = await setToken.isPendingModule(subjectNewModule);
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalModuleAdded = await setToken.isPendingModule(subjectNewModule);
-
-        expect(initialModuleAdded).to.be.false;
-        expect(finalModuleAdded).to.be.true;
-      });
-
-      it("should protect the module", async () => {
-        const initialIsProtected = await baseManager.protectedModules(subjectNewModule);
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalIsProtected = await baseManager.protectedModules(subjectNewModule);
-
-        expect(initialIsProtected).to.be.false;
-        expect(finalIsProtected).to.be.true;
-      });
-
-      it("should add and authorize the new module adapter", async () => {
-        const initialIsAdapter = await baseManager.isAdapter(subjectNewAdapter);
-        const initialIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(
-          subjectNewModule, subjectNewAdapter
-        );
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalIsAdapter = await baseManager.isAdapter(subjectNewAdapter);
-        const finalIsAuthorizedAdapter = await baseManager.isAuthorizedAdapter(
-          subjectNewModule,
-          subjectNewAdapter
-        );
-
-        expect(initialIsAdapter).to.be.false;
-        expect(finalIsAdapter).to.be.true;
-        expect(initialIsAuthorizedAdapter).to.be.false;
-        expect(finalIsAuthorizedAdapter).to.be.true;
-      });
-
-      it("should decrement the emergencies counter", async() => {
-        const initialEmergencies = await baseManager.emergencies();
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalEmergencies = await baseManager.emergencies();
-
-        expect(initialEmergencies.toNumber()).equals(1);
-        expect(finalEmergencies.toNumber()).equals(0);
-      });
-
-      it("should emit the correct EmergencyReplacedProtectedModule event", async () => {
-        await subject(operator);
-
-        await expect(subject(methodologist)).to
-          .emit(baseManager, "EmergencyReplacedProtectedModule")
-          .withArgs(subjectNewModule, [subjectNewAdapter]);
-      });
-    });
-
-    describe("when the new module is already added", async () => {
-      beforeEach(async () => {
-        baseManager.connect(operator.wallet);
-        await baseManager.addModule(subjectNewModule);
-        await baseManager.protectModule(subjectOldModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectOldModule);
-      });
-
-      it("should revert", async () => {
-        await subject(operator);
-        await expect(subject(methodologist)).to.be.revertedWith("Module must not be added");
-      });
-    });
-
-    describe("when an emergency is not in progress", async () => {
-      it("should revert", async () => {
-        await subject(operator);
-        await expect(subject(methodologist)).to.be.revertedWith("Not in emergency");
-      });
-    });
-
-    describe("when more than one emergency is in progress", async () => {
-      beforeEach(async () => {
-        baseManager.connect(operator.wallet);
-        await baseManager.protectModule(subjectOldModule, []);
-        await baseManager.protectModule(subjectAdditionalOldModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectOldModule);
-        await baseManager.emergencyRemoveProtectedModule(subjectAdditionalOldModule);
-      });
-
-      it("should remain in an emergency state after replacement", async () => {
-        const initialEmergencies = await baseManager.emergencies();
-
-        await subject(operator);
-        await subject(methodologist);
-
-        const finalEmergencies = await baseManager.emergencies();
-
-        expect(initialEmergencies.toNumber()).equals(2);
-        expect(finalEmergencies.toNumber()).equals(1);
-      });
-    });
-
-    describe("when a single mutual upgrade party calls", () => {
-      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
-        const txHash = await subject(operator);
-        await validateMutualUprade(txHash, operator.address);
-      });
-    });
-
-    describe("when the caller is not the operator or methodologist", async () => {
-      beforeEach(async () => {
-        subjectCaller = await getRandomAccount();
-      });
-
-      it("should revert", async () => {
-        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
-      });
-    });
-  });
-
-  describe("#resolveEmergency", () => {
-    let subjectModule: Address;
-    let subjectCaller: Account;
-
-    beforeEach(async () => {
-      subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectCaller = methodologist;
-    });
-
-    async function subject(): Promise<any> {
-      return baseManager.connect(subjectCaller.wallet).resolveEmergency();
-    }
-
-    describe("when an emergency is in progress", () => {
-      beforeEach(async () => {
-        await baseManager.protectModule(subjectModule, []);
-        await baseManager.emergencyRemoveProtectedModule(subjectModule);
-      });
-
-      it("should decrement the emergency counter", async () => {
-        const initialEmergencies = await baseManager.emergencies();
-
-        await subject();
-
-        const finalEmergencies = await baseManager.emergencies();
-
-        expect(initialEmergencies.toNumber()).equals(1);
-        expect(finalEmergencies.toNumber()).equals(0);
-      });
-    });
-
-    describe("when an emergency is *not* in progress", async () => {
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Not in emergency");
-      });
-    });
-
-    describe("when the caller is not the methodologist", async () => {
-      beforeEach(async () => {
-        subjectCaller = operator;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Must be methodologist");
+        await expect(subject()).to.be.revertedWith("Must be operator");
       });
     });
   });
 
   describe("#interactManager", async () => {
     let subjectModule: Address;
-    let subjectAdapter: Address;
     let subjectCallData: Bytes;
 
     beforeEach(async () => {
-      await baseManager.connect(operator.wallet).addAdapter(baseAdapter.address);
+      await baseManager.connect(owner.wallet).addAdapter(baseAdapter.address);
 
       subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdapter = baseAdapter.address;
 
       // Invoke update fee recipient
       subjectCallData = setV2Setup.streamingFeeModule.interface.encodeFunctionData("updateFeeRecipient", [
@@ -1545,68 +328,30 @@ describe("BaseManager", () => {
       return baseAdapter.interactManager(subjectModule, subjectCallData);
     }
 
-    context("when the manager is initialized", () => {
-      beforeEach(async() => {
-        await baseManager.connect(methodologist.wallet).authorizeInitialization();
-      });
-
-      it("should call updateFeeRecipient on the streaming fee module from the SetToken", async () => {
-        await subject();
-        const feeStates = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
-        expect(feeStates.feeRecipient).to.eq(otherAccount.address);
-      });
-
-      describe("when the caller is not an adapter", async () => {
-        beforeEach(async () => {
-          await baseManager.connect(operator.wallet).removeAdapter(baseAdapter.address);
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Must be adapter");
-        });
-      });
+    it("should call updateFeeRecipient on the streaming fee module from the SetToken", async () => {
+      await subject();
+      const feeStates = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
+      expect(feeStates.feeRecipient).to.eq(otherAccount.address);
     });
 
-    context("when the manager is not initialized", () => {
-      it("updateFeeRecipient should revert", async () => {
-        expect(subject()).to.be.revertedWith("Manager not initialized");
-      });
-    });
-
-    context("when the module is protected and adapter is authorized", () => {
+    describe("when the caller is not an adapter", async () => {
       beforeEach(async () => {
-        await baseManager.connect(methodologist.wallet).authorizeInitialization();
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("updateFeeRecipient should succeed", async () => {
-        await subject();
-        const feeStates = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
-        expect(feeStates.feeRecipient).to.eq(otherAccount.address);
-      });
-    });
-
-    context("when the module is protected and adapter is not authorized", () => {
-      beforeEach(async () => {
-        await baseManager.connect(methodologist.wallet).authorizeInitialization();
-        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+        await baseManager.connect(owner.wallet).removeAdapter(baseAdapter.address);
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Adapter not authorized for module");
+        await expect(subject()).to.be.revertedWith("Must be adapter");
       });
     });
   });
 
   describe("#removeModule", async () => {
     let subjectModule: Address;
-    let subjectAdapter: Address;
     let subjectCaller: Account;
 
     beforeEach(async () => {
       subjectModule = setV2Setup.streamingFeeModule.address;
-      subjectAdapter = baseAdapter.address;
-      subjectCaller = operator;
+      subjectCaller = owner;
     });
 
     async function subject(): Promise<any> {
@@ -1626,16 +371,6 @@ describe("BaseManager", () => {
 
       it("should revert", async () => {
         await expect(subject()).to.be.revertedWith("Must be operator");
-      });
-    });
-
-    describe("when the module is protected module", () => {
-      beforeEach(() => {
-        baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
-      });
-
-      it("should revert", async() => {
-        await expect(subject()).to.be.revertedWith("Module protected");
       });
     });
   });
@@ -1680,7 +415,7 @@ describe("BaseManager", () => {
 
     beforeEach(async () => {
       subjectNewOperator = await getRandomAddress();
-      subjectCaller = operator;
+      subjectCaller = owner;
     });
 
     async function subject(): Promise<any> {
@@ -1694,7 +429,7 @@ describe("BaseManager", () => {
     });
 
     it("should emit the correct OperatorChanged event", async () => {
-      await expect(subject()).to.emit(baseManager, "OperatorChanged").withArgs(operator.address, subjectNewOperator);
+      await expect(subject()).to.emit(baseManager, "OperatorChanged").withArgs(owner.address, subjectNewOperator);
     });
 
     describe("when the caller is not the operator", async () => {

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -529,6 +529,14 @@ describe("BaseManager", () => {
         expect(initialAuthorization).to.be.false;
         expect(finalAuthorization).to.be.true;
       });
+
+      it("should emit the correct AdapterAuthorized event", async () => {
+        await subject(operator);
+
+        await expect(subject(methodologist)).to
+          .emit(baseManager, "AdapterAuthorized")
+          .withArgs(subjectModule, subjectAdapter);
+      });
     });
 
     describe("when adapter is not already added to the manager", () => {
@@ -622,6 +630,14 @@ describe("BaseManager", () => {
 
         expect(initialAuthorization).to.be.true;
         expect(finalAuthorization).to.be.false;
+      });
+
+      it("should emit the correct AdapterAuthorizationRevoked event", async () => {
+        await subject(operator);
+
+        await expect(subject(methodologist)).to
+          .emit(baseManager, "AdapterAuthorizationRevoked")
+          .withArgs(subjectModule, subjectAdapter);
       });
     });
 
@@ -824,6 +840,12 @@ describe("BaseManager", () => {
         expect(initialEmergencies.toNumber()).equals(0);
         expect(finalEmergencies.toNumber()).equals(1);
       });
+
+      it("should emit the correct EmergencyRemovedProtectedModule event", async () => {
+        await expect(subject()).to
+          .emit(baseManager, "EmergencyRemovedProtectedModule")
+          .withArgs(subjectModule);
+      });
     });
 
     describe("when an emergency is already in progress", async () => {
@@ -919,6 +941,13 @@ describe("BaseManager", () => {
         expect(finalIsAdapter).to.be.true;
         expect(initialIsAuthorizedAdapter).to.be.false;
         expect(finalIsAuthorizedAdapter).to.be.true;
+      });
+
+      // With adapters...
+      it("should emit the correct ModuleProtected event", async () => {
+        await expect(subject()).to
+          .emit(baseManager, "ModuleProtected")
+          .withArgs(subjectModule, subjectAuthorizedAdapters);
       });
     });
 
@@ -1042,6 +1071,12 @@ describe("BaseManager", () => {
 
         expect(authorizedAdaptersList.length).equals(0);
         expect(isAuthorized).to.be.false;
+      });
+
+      it("should emit the correct ModuleUnprotected event", async () => {
+        await expect(subject()).to
+          .emit(baseManager, "ModuleUnprotected")
+          .withArgs(subjectModule);
       });
     });
 
@@ -1175,6 +1210,14 @@ describe("BaseManager", () => {
           expect(initialIsAuthorizedAdapter).to.be.false;
           expect(finalIsAuthorizedAdapter).to.be.true;
         });
+
+        it("should emit the correct ReplacedProtectedModule event", async () => {
+          await subject(operator);
+
+          await expect(subject(methodologist)).to
+            .emit(baseManager, "ReplacedProtectedModule")
+            .withArgs(subjectOldModule, subjectNewModule, [subjectNewAdapter]);
+        });
       });
 
       describe("when the new module is already added", async () => {
@@ -1300,6 +1343,14 @@ describe("BaseManager", () => {
 
         expect(initialEmergencies.toNumber()).equals(1);
         expect(finalEmergencies.toNumber()).equals(0);
+      });
+
+      it("should emit the correct EmergencyReplacedProtectedModule event", async () => {
+        await subject(operator);
+
+        await expect(subject(methodologist)).to
+          .emit(baseManager, "EmergencyReplacedProtectedModule")
+          .withArgs(subjectNewModule, [subjectNewAdapter]);
       });
     });
 

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -571,13 +571,20 @@ describe("BaseManager", () => {
         await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
       });
 
-      it("should revert", async () => {
-        const initialAdapterStatus = await baseManager.connect(operator.wallet).isAdapter(subjectAdapter);
+      it("should add and authorize the adapter", async () => {
+        const initialIsAdapter = await baseManager.isAdapter(subjectAdapter);
+        const initialAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
 
         await subject(operator);
+        await subject(methodologist);
 
-        await expect(initialAdapterStatus).to.be.false;
-        await expect(subject(methodologist)).to.be.revertedWith("Adapter does not exist");
+        const finalIsAdapter = await baseManager.isAdapter(subjectAdapter);
+        const finalAuthorization = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
+
+        expect(initialIsAdapter).to.be.false;
+        expect(initialAuthorization).to.be.false;
+        expect(finalIsAdapter).to.be.true;
+        expect(finalAuthorization).to.be.true;
       });
     });
 

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -603,6 +603,7 @@ describe("BaseManager", () => {
     let subjectModule: Address;
     let subjectAdditionalModule: Address;
     let subjectAdapter: Address;
+    let subjectAdditionalAdapter: Address;
     let subjectCaller: Account;
 
     beforeEach(async () => {
@@ -610,6 +611,7 @@ describe("BaseManager", () => {
       subjectModule = setV2Setup.streamingFeeModule.address;
       subjectAdditionalModule = setV2Setup.issuanceModule.address;
       subjectAdapter = baseAdapter.address;
+      subjectAdditionalAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
     });
 
     async function subject(caller: Account): Promise<any> {
@@ -659,6 +661,32 @@ describe("BaseManager", () => {
 
         const finalAuth = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
         const finalAdditionalAuth = await baseManager.isAuthorizedAdapter(subjectAdditionalModule, subjectAdapter);
+
+        expect(initialAuth).to.be.true;
+        expect(initialAdditionalAuth).to.be.true;
+        expect(finalAuth).to.be.false;
+        expect(finalAdditionalAuth).to.be.true;
+      });
+    });
+
+    // This test for the coverage report - hits an alternate branch condition the authorized
+    // adapters search method....
+    describe("when an adapter is unique and there are multiple protected modules", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addAdapter(subjectAdapter);
+        await baseManager.connect(operator.wallet).protectModule(subjectAdditionalModule, [subjectAdditionalAdapter]);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectAdapter]);
+      });
+
+      it("should only revoke authorization for the specified module", async () => {
+        const initialAuth = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
+        const initialAdditionalAuth = await baseManager.isAuthorizedAdapter(subjectAdditionalModule, subjectAdditionalAdapter);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalAuth = await baseManager.isAuthorizedAdapter(subjectModule, subjectAdapter);
+        const finalAdditionalAuth = await baseManager.isAuthorizedAdapter(subjectAdditionalModule, subjectAdditionalAdapter);
 
         expect(initialAuth).to.be.true;
         expect(initialAdditionalAuth).to.be.true;

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -147,7 +147,7 @@ describe("BaseManager", () => {
       expect(initialized).to.be.false;
     });
 
-    describe("protectedModules: single, no extensions", () => {
+    describe.skip("protectedModules: single, no extensions", () => {
       beforeEach(() => {
         subjectProtectedModules = [setV2Setup.streamingFeeModule.address];
       });
@@ -161,7 +161,7 @@ describe("BaseManager", () => {
       });
     });
 
-    describe("protectedModules: single, with multiple extension", () => {
+    describe.skip("protectedModules: single, with multiple extension", () => {
       beforeEach(async () => {
         subjectAdditionalAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
         subjectProtectedModules = [setV2Setup.streamingFeeModule.address];
@@ -185,7 +185,7 @@ describe("BaseManager", () => {
       });
     });
 
-    describe("protectedModules: multiple, with extensions", () => {
+    describe.skip("protectedModules: multiple, with extensions", () => {
       beforeEach(async () => {
         subjectAdditionalAdapter = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
         subjectProtectedModules = [setV2Setup.streamingFeeModule.address, setV2Setup.issuanceModule.address];
@@ -344,6 +344,10 @@ describe("BaseManager", () => {
       });
     });
 
+    describe.skip("when an emergency is in progress", async () => {
+      it("should revert", async () => {});
+    });
+
     describe("when the caller is not the operator", async () => {
       beforeEach(async () => {
         subjectCaller = methodologist;
@@ -421,12 +425,102 @@ describe("BaseManager", () => {
     });
   });
 
-  describe("#authorizeAdapter", () => {
+  describe.skip("#authorizeAdapter", () => {
+    let subjectModule: Address;
+    let subjectAdapter: Address;
+    let subjectCaller: Account;
 
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectAdapter = baseAdapter.address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager.connect(caller.wallet).protectAuthorizeAdapter(subjectModule, [subjectAdapter]);
+    }
+
+    describe.skip("when adapter is not authorized and already added", () => {
+
+    });
+
+    describe.skip("when adapter is not already added", () => {
+      it("should revert", () => {});
+    });
+
+    describe.skip("when the adapter is already authorized for target module", () => {
+      it("should revert", () => {});
+    });
+
+    describe.skip("when target module is not protected", () => {
+      it("should revert", () => {});
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
   });
 
-  describe("#revokeAdapterAuthorization", () => {
+  describe.skip("#revokeAdapterAuthorization", () => {
+    let subjectModule: Address;
+    let subjectAdapter: Address;
+    let subjectCaller: Account;
 
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectAdapter = baseAdapter.address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager.connect(caller.wallet).revokeAdapterAuthorization(subjectModule, subjectAdapter);
+    }
+
+    describe.skip("when adapter is authorized", () => {
+
+    });
+
+    describe.skip("when adapter is not added to the manager", () => {
+      it("should revert", () => {});
+    });
+
+    describe.skip("when the adapter is not authorized for target module", () => {
+      it("should revert", () => {});
+    });
+
+    describe.skip("when target module is not protected", () => {
+      it("should revert", () => {});
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
   });
 
   describe("#addModule", async () => {
@@ -448,6 +542,10 @@ describe("BaseManager", () => {
       await subject();
       const isModule = await setToken.isPendingModule(subjectModule);
       expect(isModule).to.eq(true);
+    });
+
+    describe.skip("when an emergency is in progress", async () => {
+      it("should revert", async () => {});
     });
 
     describe("when the caller is not the operator", async () => {
@@ -475,14 +573,20 @@ describe("BaseManager", () => {
     }
 
     describe("when module is protected", () => {
-      it("should remove the module from the set token", async () => {});
-      it("should unprotect the module", () => {});
-      it("should clear the protected modules authorized extension registries", () => {});
-      it("should increment the emergencies counter", async () => {});
+      it.skip("should remove the module from the set token", async () => {});
+      it.skip("should unprotect the module", () => {});
+      it.skip("should clear the protected modules authorized extension registries", () => {});
+      it.skip("should increment the emergencies counter", async () => {});
+    });
+
+    describe("when an emergency is already in progress", async () => {
+      it.skip("should increment the emergencies counter", async () => {
+
+      });
     });
 
     describe("when module is not protected", () => {
-      it("should revert", async () => {});
+      it.skip("should revert", async () => {});
     });
 
     describe("when the caller is not the operator", async () => {
@@ -511,24 +615,28 @@ describe("BaseManager", () => {
       return baseManager.connect(subjectCaller.wallet).protectModule(subjectModule, [subjectAdapter]);
     }
 
-    describe("when module already added, no extensions", () => {
+    describe.skip("when module already added, no extensions", () => {
 
     });
 
-    describe("when module already added, with non-added extension", () => {
+    describe.skip("when module already added, with non-added extension", () => {
 
     });
 
-    describe("when module already added, with added extension", () => {
+    describe.skip("when module already added, with added extension", () => {
 
     });
 
-    describe("when module not added", () => {
+    describe.skip("when module not added", () => {
 
     });
 
-    describe("when module already protected", () => {
+    describe.skip("when module already protected", () => {
 
+    });
+
+    describe.skip("when an emergency is in progress", async () => {
+      it("should revert", async () => {});
     });
 
     describe("when the caller is not the operator", async () => {
@@ -555,11 +663,12 @@ describe("BaseManager", () => {
       return baseManager.connect(subjectCaller.wallet).unProtectModule(subjectModule);
     }
 
-    describe("when module is protected", () => {
-
+    describe.skip("when module is protected", () => {
+      it.skip("should unprotect the module", () => {});
+      it.skip("should clear the protected modules authorized extension registries", () => {});
     });
 
-    describe("when module is not protected", () => {
+    describe.skip("when module is not protected", () => {
 
     });
 
@@ -575,15 +684,188 @@ describe("BaseManager", () => {
   });
 
   describe("#replaceProtectedModule", () => {
+    let subjectOldModule: Address;
+    let subjectNewModule: Address;
+    let subjectAdapter: Address;
+    let subjectCaller: Account;
 
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectOldModule = setV2Setup.issuanceModule.address;
+      subjectNewModule = setV2Setup.streamingFeeModule.address;
+      subjectAdapter = baseAdapter.address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager
+        .connect(caller.wallet)
+        .replaceProtectedModule(subjectOldModule, subjectNewModule, [subjectAdapter]);
+    }
+
+    describe("when old module is protected", () => {
+      describe.skip("when new module is not added", () => {
+        it("should add module to setToken", () => {
+
+        });
+
+        it("should protect the module", async () => {
+
+        });
+
+        it("should add extensions which aren't already added", async() => {
+
+        });
+
+        it("should authorize the extensions", async() => {
+
+        });
+      });
+
+      describe.skip("when the new module is already added", async () => {
+        it("should revert", async () => {
+
+        });
+      });
+
+      describe.skip("when the new module is already protected", async () => {
+        it("should revert", async () => {
+
+        });
+      });
+    });
+
+    describe.skip("when old module is not protected", () => {
+      it("should revert", () => {
+
+      });
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
   });
 
   describe("#emergencyReplaceProtectedModule", () => {
+    let subjectNewModule: Address;
+    let subjectAdapter: Address;
+    let subjectCaller: Account;
 
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectNewModule = setV2Setup.streamingFeeModule.address;
+      subjectAdapter = baseAdapter.address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager
+        .connect(caller.wallet)
+        .emergencyReplaceProtectedModule(subjectNewModule, [subjectAdapter]);
+    }
+
+
+    describe.skip("when new module is not added", () => {
+      it("should add module to setToken", () => {
+
+      });
+
+      it("should protect the module", async () => {
+
+      });
+
+      it("should add extensions which aren't already added", async() => {
+
+      });
+
+      it("should authorize the extensions", async() => {
+
+      });
+
+      it("should decrement the emergencies counter", async() => {
+
+      });
+    });
+
+    describe.skip("when the new module is already added", async () => {
+      it("should revert", async () => {
+
+      });
+    });
+
+    describe.skip("when the new module is already protected", async () => {
+      it("should revert", async () => {
+
+      });
+    });
+
+    describe.skip("when an emergency is not in progress", async () => {
+      it("should revert", async () => {});
+    });
+
+    describe.skip("when more than one emergency is in progress", async () => {
+      it("should remain in an emergency state after replacement", async () => {
+
+      });
+    });
+
+    describe.skip("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe.skip("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
   });
 
   describe("#resolveEmergency", () => {
+    let subjectCaller: Account;
 
+    beforeEach(async () => {
+      subjectCaller = methodologist;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).resolveEmergency();
+    }
+
+    it.skip("should decrement the emergency counter", async () => {
+
+    });
+
+    describe.skip("when an emergency is not in progress", async () => {
+      it("should revert", async () => {});
+    });
+
+    describe.skip("when the caller is not the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = operator;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be authorized");
+      });
+    });
   });
 
   describe("#interactManager", async () => {

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { Address, Account, Bytes } from "@utils/types";
 import { ADDRESS_ZERO, ZERO } from "@utils/constants";
-import { BaseManager, BaseAdapterMock } from "@utils/contracts/index";
+import { BaseManager, BaseExtensionMock } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -29,7 +29,7 @@ describe("BaseManager", () => {
   let setToken: SetToken;
 
   let baseManager: BaseManager;
-  let baseAdapter: BaseAdapterMock;
+  let baseAdapter: BaseExtensionMock;
 
   before(async () => {
     [
@@ -73,7 +73,7 @@ describe("BaseManager", () => {
     // Transfer ownership to BaseManager
     await setToken.setManager(baseManager.address);
 
-    baseAdapter = await deployer.mocks.deployBaseAdapterMock(baseManager.address);
+    baseAdapter = await deployer.mocks.deployBaseExtensionMock(baseManager.address);
   });
 
   addSnapshotBeforeRestoreAfterEach();
@@ -203,7 +203,7 @@ describe("BaseManager", () => {
 
     describe("when adapter has different manager address", async () => {
       beforeEach(async () => {
-        subjectAdapter = (await deployer.mocks.deployBaseAdapterMock(await getRandomAddress())).address;
+        subjectAdapter = (await deployer.mocks.deployBaseExtensionMock(await getRandomAddress())).address;
       });
 
       it("should revert", async () => {

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -303,6 +303,16 @@ describe("BaseManager", () => {
         await expect(subject()).to.be.revertedWith("Must be methodologist");
       });
     });
+
+    describe("when the manager is already initialized", async () => {
+      beforeEach(async () => {
+        await subject();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Initialization authorized");
+      });
+    });
   });
 
   describe("#setManager", async () => {

--- a/test/manager/baseManagerV2.spec.ts
+++ b/test/manager/baseManagerV2.spec.ts
@@ -156,18 +156,9 @@ describe("BaseManagerV2", () => {
       expect(initialized).to.be.false;
     });
 
-    describe("protectedModules: single, no extensions", () => {
+    describe("protectedModules: single, no extensions, module already added", () => {
       beforeEach(() => {
         subjectProtectedModules = [subjectModule];
-      });
-
-      // This test is borked... module initialized in before block..
-      it("should add module to setToken", async () => {
-        await subject();
-
-        const initialized = await setToken.isInitializedModule(subjectModule);
-
-        expect(initialized).to.be.true;
       });
 
       it("should protect the module", async () => {
@@ -182,6 +173,28 @@ describe("BaseManagerV2", () => {
 
         const protectedModules = await retrievedICManager.getProtectedModules();
         expect(protectedModules.includes(subjectModule)).to.be.true;
+      });
+    });
+
+    describe("protectedModules: when module is not yet added", () => {
+      beforeEach(async () => {
+        await setV2Setup.controller.addModule(otherAccount.address);
+
+        subjectModule = otherAccount.address;
+        subjectProtectedModules = [subjectModule];
+      });
+
+      it("should be possible to add protected module to setToken after deployment", async () => {
+        await subject();
+
+        const initialIsPending = await setToken.isPendingModule(subjectModule);
+
+        await baseManager.connect(operator.wallet).addModule(subjectModule);
+
+        const finalIsPending = await setToken.isPendingModule(subjectModule);
+
+        expect(initialIsPending).to.be.false;
+        expect(finalIsPending).to.be.true;
       });
     });
 

--- a/test/manager/baseManagerV2.spec.ts
+++ b/test/manager/baseManagerV2.spec.ts
@@ -1,0 +1,1710 @@
+import "module-alias/register";
+
+import { Address, Account, Bytes } from "@utils/types";
+import { ADDRESS_ZERO, ZERO } from "@utils/constants";
+import { BaseManagerV2, BaseAdapterMock } from "@utils/contracts/index";
+import { SetToken } from "@utils/contracts/setV2";
+import DeployHelper from "@utils/deploys";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  ether,
+  getAccounts,
+  getSetFixture,
+  getWaffleExpect,
+  getRandomAccount,
+  getRandomAddress
+} from "@utils/index";
+import { SetFixture } from "@utils/fixtures";
+
+import { solidityKeccak256 } from "ethers/lib/utils";
+import { ContractTransaction } from "ethers";
+
+const expect = getWaffleExpect();
+
+describe("BaseManagerV2", () => {
+  let operator: Account;
+  let methodologist: Account;
+  let otherAccount: Account;
+  let newManager: Account;
+  let setV2Setup: SetFixture;
+
+  let deployer: DeployHelper;
+  let setToken: SetToken;
+
+  let baseManager: BaseManagerV2;
+  let baseExtension: BaseAdapterMock;
+
+  async function validateMutualUprade(txHash: ContractTransaction, caller: Address) {
+    const expectedHash = solidityKeccak256(["bytes", "address"], [txHash.data, caller]);
+    const isLogged = await baseManager.mutualUpgrades(expectedHash);
+    expect(isLogged).to.be.true;
+  }
+
+  before(async () => {
+    [
+      operator,
+      otherAccount,
+      newManager,
+      methodologist,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(operator.wallet);
+
+    setV2Setup = getSetFixture(operator.address);
+    await setV2Setup.initialize();
+
+    setToken = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address],
+      [ether(1)],
+      [
+        setV2Setup.issuanceModule.address,
+        setV2Setup.streamingFeeModule.address,
+        setV2Setup.governanceModule.address,
+      ]
+    );
+
+    // Initialize modules
+    await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
+    await setV2Setup.governanceModule.initialize(setToken.address);
+
+    const feeRecipient = operator.address;
+    const maxStreamingFeePercentage = ether(.1);
+    const streamingFeePercentage = ether(.02);
+    const streamingFeeSettings = {
+      feeRecipient,
+      maxStreamingFeePercentage,
+      streamingFeePercentage,
+      lastStreamingFeeTimestamp: ZERO,
+    };
+    await setV2Setup.streamingFeeModule.initialize(setToken.address, streamingFeeSettings);
+
+    // Deploy BaseManager
+    baseManager = await deployer.manager.deployBaseManagerV2(
+      setToken.address,
+      operator.address,
+      methodologist.address,
+      [],
+      [[]]
+    );
+
+    // Transfer operatorship to BaseManager
+    await setToken.setManager(baseManager.address);
+
+    baseExtension = await deployer.mocks.deployBaseAdapterMock(baseManager.address);
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("#constructor", async () => {
+    let subjectSetToken: Address;
+    let subjectExtension: Address;
+    let subjectModule: Address;
+    let subjectAdditionalModule: Address;
+    let subjectAdditionalExtension: Address;
+    let subjectOperator: Address;
+    let subjectMethodologist: Address;
+    let subjectProtectedModules: Address[];
+    let subjectAuthorizedExtensions: Address[][];
+
+    beforeEach(async () => {
+      subjectSetToken = setToken.address;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectAdditionalModule = setV2Setup.issuanceModule.address;
+      subjectExtension = baseExtension.address;
+      subjectAdditionalExtension = ADDRESS_ZERO; // Deploy as needed
+      subjectOperator = operator.address;
+      subjectMethodologist = methodologist.address;
+      subjectProtectedModules = [subjectModule];
+      subjectAuthorizedExtensions = [[]];
+    });
+
+    async function subject(): Promise<BaseManagerV2> {
+      return await deployer.manager.deployBaseManagerV2(
+        subjectSetToken,
+        subjectOperator,
+        subjectMethodologist,
+        subjectProtectedModules,
+        subjectAuthorizedExtensions
+      );
+    }
+
+    it("should set the correct SetToken address", async () => {
+      const retrievedICManager = await subject();
+
+      const actualToken = await retrievedICManager.setToken();
+      expect (actualToken).to.eq(subjectSetToken);
+    });
+
+    it("should set the correct Operator address", async () => {
+      const retrievedICManager = await subject();
+
+      const actualOperator = await retrievedICManager.operator();
+      expect (actualOperator).to.eq(subjectOperator);
+    });
+
+    it("should set the correct Methodologist address", async () => {
+      const retrievedICManager = await subject();
+
+      const actualMethodologist = await retrievedICManager.methodologist();
+      expect (actualMethodologist).to.eq(subjectMethodologist);
+    });
+
+    it("should not be initialized by default", async () => {
+      const retrievedICManager = await subject();
+
+      const initialized = await retrievedICManager.initialized();
+      expect(initialized).to.be.false;
+    });
+
+    describe("protectedModules: single, no extensions", () => {
+      beforeEach(() => {
+        subjectProtectedModules = [subjectModule];
+      });
+
+      // This test is borked... module initialized in before block..
+      it("should add module to setToken", async () => {
+        await subject();
+
+        const initialized = await setToken.isInitializedModule(subjectModule);
+
+        expect(initialized).to.be.true;
+      });
+
+      it("should protect the module", async () => {
+        const retrievedICManager = await subject();
+
+        const isProtected = await retrievedICManager.protectedModules(subjectModule);
+        expect(isProtected).to.be.true;
+      });
+
+      it("should be added to the protectedModules list", async () => {
+        const retrievedICManager = await subject();
+
+        const protectedModules = await retrievedICManager.getProtectedModules();
+        expect(protectedModules.includes(subjectModule)).to.be.true;
+      });
+    });
+
+    describe("protectedModules: single, with multiple extension", () => {
+      beforeEach(async () => {
+        subjectAdditionalExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+        subjectProtectedModules = [subjectModule];
+        subjectAuthorizedExtensions = [[subjectExtension, subjectAdditionalExtension]];
+      });
+
+      it("should protect the module", async () => {
+        const retrievedICManager = await subject();
+
+        const isProtected = await retrievedICManager.protectedModules(subjectModule);
+        expect(isProtected).to.be.true;
+      });
+
+      it("should add the extensions", async () => {
+        const retrievedICManager = await subject();
+
+        const isSubjectExtension = await retrievedICManager.isExtension(subjectExtension);
+        const isSubjectAdditionalExtension = await retrievedICManager.isExtension(subjectAdditionalExtension);
+
+        expect(isSubjectExtension).to.be.true;
+        expect(isSubjectAdditionalExtension).to.be.true;
+      });
+
+      it("should authorize the extensions for the module", async () => {
+        const retrievedICManager = await subject();
+
+        const isAuthorizedSubjectExtension = await retrievedICManager
+          .isAuthorizedExtension(subjectModule, subjectExtension);
+
+        const isAuthorizedSubjectAdditionalExtension = await retrievedICManager
+          .isAuthorizedExtension(subjectModule, subjectAdditionalExtension);
+
+        expect(isAuthorizedSubjectExtension).to.be.true;
+        expect(isAuthorizedSubjectAdditionalExtension).to.be.true;
+      });
+    });
+
+    describe("protectedModules: multiple, with extensions", () => {
+      beforeEach(async () => {
+        subjectAdditionalExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+        subjectProtectedModules = [subjectModule, subjectAdditionalModule];
+        subjectAuthorizedExtensions = [ [subjectExtension], [subjectAdditionalExtension] ];
+      });
+
+      it("should protect the module", async () => {
+        const retrievedICManager = await subject();
+
+        const isProtectedSubjectModule = await retrievedICManager
+          .protectedModules(subjectModule);
+
+        const isProtectedSubjectAdditionalModule = await retrievedICManager
+          .protectedModules(subjectAdditionalModule);
+
+        expect(isProtectedSubjectModule).to.be.true;
+        expect(isProtectedSubjectAdditionalModule).to.be.true;
+      });
+
+      it("should add the extensions", async () => {
+        const retrievedICManager = await subject();
+
+        const isSubjectExtension = await retrievedICManager.isExtension(subjectExtension);
+        const isSubjectAdditionalExtension = await retrievedICManager.isExtension(subjectAdditionalExtension);
+
+        expect(isSubjectExtension).to.be.true;
+        expect(isSubjectAdditionalExtension).to.be.true;
+      });
+
+      it("should authorize the extensions correctly", async () => {
+        const retrievedICManager = await subject();
+
+        const isAuthorizedSubjectExtension = await retrievedICManager
+          .isAuthorizedExtension(subjectModule, subjectExtension);
+
+        const isAuthorizedSubjectAdditionalExtension = await retrievedICManager
+          .isAuthorizedExtension(subjectAdditionalModule, subjectAdditionalExtension);
+
+        const transposedExtensionIsAuthorized = await retrievedICManager
+          .isAuthorizedExtension(subjectModule, subjectAdditionalExtension);
+
+        expect(isAuthorizedSubjectExtension).to.be.true;
+        expect(isAuthorizedSubjectAdditionalExtension).to.be.true;
+        expect(transposedExtensionIsAuthorized).to.be.false;
+      });
+    });
+  });
+
+  describe("#authorizeInitialization", () => {
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectCaller = methodologist;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).authorizeInitialization();
+    }
+
+    it("sets initialized to true", async() => {
+      const defaultInitialized = await baseManager.initialized();
+
+      await subject();
+
+      const updatedInitialized = await baseManager.initialized();
+
+      expect(defaultInitialized).to.be.false;
+      expect(updatedInitialized).to.be.true;
+    });
+
+    describe("when the caller is not the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be methodologist");
+      });
+    });
+
+    describe("when the manager is already initialized", async () => {
+      beforeEach(async () => {
+        await subject();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Initialization authorized");
+      });
+    });
+  });
+
+  describe("#setManager", async () => {
+    let subjectNewManager: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectNewManager = newManager.address;
+      subjectCaller = operator;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager.connect(caller.wallet).setManager(subjectNewManager);
+    }
+
+    it("should change the manager address", async () => {
+      await subject(operator);
+      await subject(methodologist);
+      const manager = await setToken.manager();
+
+      expect(manager).to.eq(newManager.address);
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when passed manager is the zero address", async () => {
+      beforeEach(async () => {
+        subjectNewManager = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await subject(operator);
+        await expect(subject(methodologist)).to.be.revertedWith("Zero address not valid");
+      });
+    });
+
+    describe("when the caller is not the operator or the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized address");
+      });
+    });
+  });
+
+  describe("#addExtension", async () => {
+    let subjectModule: Address;
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectExtension = baseExtension.address;
+      subjectCaller = operator;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).addExtension(subjectExtension);
+    }
+
+    it("should add the extension address", async () => {
+      await subject();
+      const extensions = await baseManager.getExtensions();
+
+      expect(extensions[0]).to.eq(baseExtension.address);
+    });
+
+    it("should set the extension mapping", async () => {
+      await subject();
+      const isExtension = await baseManager.isExtension(subjectExtension);
+
+      expect(isExtension).to.be.true;
+    });
+
+    it("should emit the correct ExtensionAdded event", async () => {
+      await expect(subject()).to.emit(baseManager, "ExtensionAdded").withArgs(baseExtension.address);
+    });
+
+    describe("when the extension already exists", async () => {
+      beforeEach(async () => {
+        await subject();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Extension already exists");
+      });
+    });
+
+    describe("when extension has different manager address", async () => {
+      beforeEach(async () => {
+        subjectExtension = (await deployer.mocks.deployBaseAdapterMock(await getRandomAddress())).address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Extension manager invalid");
+      });
+    });
+
+    describe("when an emergency is in progress", async () => {
+      beforeEach(async () => {
+        baseManager.connect(operator.wallet);
+        await baseManager.protectModule(subjectModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectModule);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Upgrades paused by emergency");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#removeExtension", async () => {
+    let subjectModule: Address;
+    let subjectAdditionalModule: Address;
+    let subjectExtension: Address;
+    let subjectAdditionalExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      await baseManager.connect(operator.wallet).addExtension(baseExtension.address);
+
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectAdditionalModule = setV2Setup.issuanceModule.address;
+      subjectExtension = baseExtension.address;
+      subjectAdditionalExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+      subjectCaller = operator;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).removeExtension(subjectExtension);
+    }
+
+    it("should remove the extension address", async () => {
+      await subject();
+      const extensions = await baseManager.getExtensions();
+
+      expect(extensions.length).to.eq(0);
+    });
+
+    it("should set the extension mapping", async () => {
+      await subject();
+      const isExtension = await baseManager.isExtension(subjectExtension);
+
+      expect(isExtension).to.be.false;
+    });
+
+    it("should emit the correct ExtensionRemoved event", async () => {
+      await expect(subject()).to.emit(baseManager, "ExtensionRemoved").withArgs(baseExtension.address);
+    });
+
+    describe("when the extension does not exist", async () => {
+      beforeEach(async () => {
+        subjectExtension = await getRandomAddress();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Extension does not exist");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+
+    describe("when the extension is authorized for a protected module", () => {
+      beforeEach(() => {
+        baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should revert", async() => {
+        await expect(subject()).to.be.revertedWith("Extension used by protected module");
+      });
+    });
+
+    // This test for the coverage report - hits an alternate branch condition the authorized
+    // extensions search method....
+    describe("when multiple extensionsa are authorized for multiple protected modules", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).protectModule(subjectAdditionalModule, [subjectAdditionalExtension]);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should revert", async() => {
+        await expect(subject()).to.be.revertedWith("Extension used by protected module");
+      });
+    });
+  });
+
+  describe("#authorizeExtension", () => {
+    let subjectModule: Address;
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectExtension = baseExtension.address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager.connect(caller.wallet).authorizeExtension(subjectModule, subjectExtension);
+    }
+
+    describe("when extension is not authorized and already added", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+      });
+
+      it("should authorize the extension", async () => {
+        const initialAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialAuthorization).to.be.false;
+        expect(finalAuthorization).to.be.true;
+      });
+
+      it("should emit the correct ExtensionAuthorized event", async () => {
+        await subject(operator);
+
+        await expect(subject(methodologist)).to
+          .emit(baseManager, "ExtensionAuthorized")
+          .withArgs(subjectModule, subjectExtension);
+      });
+    });
+
+    describe("when extension is not already added to the manager", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+      });
+
+      it("should add and authorize the extension", async () => {
+        const initialIsExtension = await baseManager.isExtension(subjectExtension);
+        const initialAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalIsExtension = await baseManager.isExtension(subjectExtension);
+        const finalAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialIsExtension).to.be.false;
+        expect(initialAuthorization).to.be.false;
+        expect(finalIsExtension).to.be.true;
+        expect(finalAuthorization).to.be.true;
+      });
+    });
+
+    describe("when the extension is already authorized for target module", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should revert", async () => {
+        await subject(operator);
+        await expect(subject(methodologist)).to.be.revertedWith("Extension already authorized");
+      });
+    });
+
+    describe("when target module is not protected", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+      });
+
+      it("should revert", async () => {
+        const isProtected = await baseManager.protectedModules(subjectModule);
+
+        await subject(operator);
+
+        await expect(isProtected).to.be.false;
+        await expect(subject(methodologist)).to.be.revertedWith("Module not protected");
+      });
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
+  });
+
+  describe("#revokeExtensionAuthorization", () => {
+    let subjectModule: Address;
+    let subjectAdditionalModule: Address;
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectAdditionalModule = setV2Setup.issuanceModule.address;
+      subjectExtension = baseExtension.address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager.connect(caller.wallet).revokeExtensionAuthorization(subjectModule, subjectExtension);
+    }
+
+    describe("when extension is authorized", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should revoke extension authorization", async () => {
+        const initialAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialAuthorization).to.be.true;
+        expect(finalAuthorization).to.be.false;
+      });
+
+      it("should emit the correct ExtensionAuthorizationRevoked event", async () => {
+        await subject(operator);
+
+        await expect(subject(methodologist)).to
+          .emit(baseManager, "ExtensionAuthorizationRevoked")
+          .withArgs(subjectModule, subjectExtension);
+      });
+    });
+
+    describe("when an extension is shared by protected modules", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+        await baseManager.connect(operator.wallet).protectModule(subjectAdditionalModule, [subjectExtension]);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should only revoke authorization for the specified module", async () => {
+        const initialAuth = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+        const initialAdditionalAuth = await baseManager.isAuthorizedExtension(subjectAdditionalModule, subjectExtension);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalAuth = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+        const finalAdditionalAuth = await baseManager.isAuthorizedExtension(subjectAdditionalModule, subjectExtension);
+
+        expect(initialAuth).to.be.true;
+        expect(initialAdditionalAuth).to.be.true;
+        expect(finalAuth).to.be.false;
+        expect(finalAdditionalAuth).to.be.true;
+      });
+    });
+
+    describe("when extension is not added to the manager", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+      });
+
+      it("should revert", async () => {
+        const initialExtensionStatus = await baseManager.connect(operator.wallet).isExtension(subjectExtension);
+
+        await subject(operator);
+
+        await expect(initialExtensionStatus).to.be.false;
+        await expect(subject(methodologist)).to.be.revertedWith("Extension does not exist");
+      });
+    });
+
+    describe("when the extension is not authorized for target module", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+      });
+
+      it("should revert", async () => {
+        const initialAuthorization = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject(operator);
+        await expect(initialAuthorization).to.be.false;
+        await expect(subject(methodologist)).to.be.revertedWith("Extension not authorized");
+      });
+    });
+
+    describe("when target module is not protected", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+      });
+
+      it("should revert", async () => {
+        const isProtected = await baseManager.protectedModules(subjectModule);
+
+        await subject(operator);
+
+        await expect(isProtected).to.be.false;
+        await expect(subject(methodologist)).to.be.revertedWith("Module not protected");
+      });
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
+  });
+
+  describe("#addModule", async () => {
+    let subjectModule: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      await setV2Setup.controller.addModule(otherAccount.address);
+
+      subjectModule = otherAccount.address;
+      subjectCaller = operator;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).addModule(subjectModule);
+    }
+
+    it("should add the module to the SetToken", async () => {
+      await subject();
+      const isModule = await setToken.isPendingModule(subjectModule);
+      expect(isModule).to.eq(true);
+    });
+
+    describe("when an emergency is in progress", async () => {
+      beforeEach(async () => {
+        subjectModule = setV2Setup.streamingFeeModule.address;
+        await baseManager.protectModule(subjectModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectModule);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Upgrades paused by emergency");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#emergencyRemoveProtectedModule", () => {
+    let subjectModule: Address;
+    let subjectAdditionalModule: Address;
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectAdditionalModule = setV2Setup.governanceModule.address; // Removable
+      subjectExtension = baseExtension.address;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).emergencyRemoveProtectedModule(subjectModule);
+    }
+
+    describe("when module is protected", async () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should remove the module from the set token", async () => {
+        await subject();
+        const isModule = await setToken.isInitializedModule(subjectModule);
+        expect(isModule).to.eq(false);
+      });
+
+      it("should unprotect the module", async () => {
+        await subject();
+        const isProtected = await baseManager.protectedModules(subjectModule);
+        expect(isProtected).to.be.false;
+      });
+
+      it("should clear the protected modules authorized extension registries", async () => {
+        const initialAuthorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectModule);
+        const initialIsAuthorized = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject();
+
+        const finalAuthorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectModule);
+        const finalIsAuthorized = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialAuthorizedExtensionsList.length).equals(1);
+        expect(initialIsAuthorized).to.be.true;
+        expect(finalAuthorizedExtensionsList.length).equals(0);
+        expect(finalIsAuthorized).to.be.false;
+      });
+
+      it("should not preserve any settings if same module is removed and restored", async () => {
+        await subject();
+
+        await baseManager.connect(methodologist.wallet).resolveEmergency();
+        await baseManager.connect(operator.wallet).addModule(subjectModule);
+
+        // Invoke initialize on streamingFeeModule
+        const feeRecipient = operator.address;
+        const maxStreamingFeePercentage = ether(.1);
+        const streamingFeePercentage = ether(.02);
+        const streamingFeeSettings = {
+          feeRecipient,
+          maxStreamingFeePercentage,
+          streamingFeePercentage,
+          lastStreamingFeeTimestamp: ZERO,
+        };
+
+        const initializeData = setV2Setup
+          .streamingFeeModule
+          .interface
+          .encodeFunctionData("initialize", [setToken.address, streamingFeeSettings]);
+
+        await baseManager.connect(methodologist.wallet).authorizeInitialization();
+        await baseExtension.interactManager(subjectModule, initializeData);
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+
+        const authorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectModule);
+        const isAuthorized = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(authorizedExtensionsList.length).equals(0);
+        expect(isAuthorized).to.be.false;
+      });
+
+      it("should increment the emergencies counter", async () => {
+        const initialEmergencies = await baseManager.emergencies();
+
+        await subject();
+
+        const finalEmergencies = await baseManager.emergencies();
+
+        expect(initialEmergencies.toNumber()).equals(0);
+        expect(finalEmergencies.toNumber()).equals(1);
+      });
+
+      it("should emit the correct EmergencyRemovedProtectedModule event", async () => {
+        await expect(subject()).to
+          .emit(baseManager, "EmergencyRemovedProtectedModule")
+          .withArgs(subjectModule);
+      });
+    });
+
+    describe("when an emergency is already in progress", async () => {
+      beforeEach(async () => {
+        baseManager.connect(operator.wallet);
+
+        await baseManager.protectModule(subjectModule, []);
+        await baseManager.protectModule(subjectAdditionalModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectAdditionalModule);
+      });
+
+      it("should increment the emergencies counter", async () => {
+        const initialEmergencies = await baseManager.emergencies();
+
+        await subject();
+
+        const finalEmergencies = await baseManager.emergencies();
+
+        expect(initialEmergencies.toNumber()).equals(1);
+        expect(finalEmergencies.toNumber()).equals(2);
+      });
+    });
+
+    describe("when module is not protected", () => {
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Module not protected");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#protectModule", () => {
+    let subjectModule: Address;
+    let subjectAdditionalModule: Address;
+    let subjectExtension: Address;
+    let subjectAuthorizedExtensions: Address[];
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectCaller = operator;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectExtension = baseExtension.address;
+      subjectAdditionalModule = setV2Setup.governanceModule.address; // Removable
+      subjectAuthorizedExtensions = [];
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager
+        .connect(subjectCaller.wallet)
+        .protectModule(subjectModule, subjectAuthorizedExtensions);
+    }
+
+    describe("when module already added, no extensions", () => {
+      it("should protect the module", async () => {
+        const initialIsProtected = await baseManager.protectedModules(subjectModule);
+        const initialProtectedModulesList = await baseManager.getProtectedModules();
+
+        await subject();
+
+        const finalIsProtected = await baseManager.protectedModules(subjectModule);
+        const finalProtectedModulesList = await baseManager.getProtectedModules();
+
+        expect(initialIsProtected).to.be.false;
+        expect(finalIsProtected).to.be.true;
+        expect(initialProtectedModulesList.length).equals(0);
+        expect(finalProtectedModulesList.length).equals(1);
+      });
+    });
+
+    describe("when module already added, with non-added extension", () => {
+      beforeEach(() => {
+        subjectAuthorizedExtensions = [subjectExtension];
+      });
+      it("should add and authorize the extension", async () => {
+        const initialIsExtension = await baseManager.isExtension(subjectExtension);
+        const initialIsAuthorizedExtension = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject();
+
+        const finalIsExtension = await baseManager.isExtension(subjectExtension);
+        const finalIsAuthorizedExtension = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialIsExtension).to.be.false;
+        expect(finalIsExtension).to.be.true;
+        expect(initialIsAuthorizedExtension).to.be.false;
+        expect(finalIsAuthorizedExtension).to.be.true;
+      });
+
+      // With extensions...
+      it("should emit the correct ModuleProtected event", async () => {
+        await expect(subject()).to
+          .emit(baseManager, "ModuleProtected")
+          .withArgs(subjectModule, subjectAuthorizedExtensions);
+      });
+    });
+
+    describe("when module and extension already added", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).addExtension(subjectExtension);
+        subjectAuthorizedExtensions = [subjectExtension];
+      });
+
+      it("should authorize the extension", async () => {
+        const initialIsExtension = await baseManager.isExtension(subjectExtension);
+        const initialIsAuthorizedExtension = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject();
+
+        const finalIsAuthorizedExtension = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialIsExtension).to.be.true;
+        expect(initialIsAuthorizedExtension).to.be.false;
+        expect(finalIsAuthorizedExtension).to.be.true;
+      });
+    });
+
+    describe("when module not added", () => {
+      beforeEach(async () => {
+        await baseManager.removeModule(subjectModule);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Module not added yet");
+      });
+    });
+
+    describe("when module already protected", () => {
+      beforeEach(async () => {
+        await baseManager.protectModule(subjectModule, []);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Module already protected");
+      });
+    });
+
+    describe("when an emergency is in progress", async () => {
+      beforeEach(async () => {
+        await baseManager.protectModule(subjectAdditionalModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectAdditionalModule);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Upgrades paused by emergency");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#unProtectModule", () => {
+    let subjectModule: Address;
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectCaller = methodologist;
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectExtension = baseExtension.address;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).unProtectModule(subjectModule);
+    }
+
+    describe("when module is protected", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should *not* remove the module from the set token", async () => {
+        await subject();
+        const isModule = await setToken.isInitializedModule(subjectModule);
+        expect(isModule).to.be.true;
+      });
+
+      it("should unprotect the module", async () => {
+        await subject();
+        const isProtected = await baseManager.protectedModules(subjectModule);
+        expect(isProtected).to.be.false;
+      });
+
+      it("should clear the protected modules authorized extension registries", async () => {
+        const initialAuthorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectModule);
+        const initialIsAuthorized = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        await subject();
+
+        const finalAuthorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectModule);
+        const finalIsAuthorized = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(initialAuthorizedExtensionsList.length).equals(1);
+        expect(initialIsAuthorized).to.be.true;
+        expect(finalAuthorizedExtensionsList.length).equals(0);
+        expect(finalIsAuthorized).to.be.false;
+      });
+
+      it("should not preserve any settings if same module is removed and restored", async () => {
+        await subject();
+
+        // Restore without extension
+        await baseManager.protectModule(subjectModule, []);
+
+        const authorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectModule);
+        const isAuthorized = await baseManager.isAuthorizedExtension(subjectModule, subjectExtension);
+
+        expect(authorizedExtensionsList.length).equals(0);
+        expect(isAuthorized).to.be.false;
+      });
+
+      it("should emit the correct ModuleUnprotected event", async () => {
+        await expect(subject()).to
+          .emit(baseManager, "ModuleUnprotected")
+          .withArgs(subjectModule);
+      });
+    });
+
+    describe("when module is not protected", () => {
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Module not protected");
+      });
+    });
+
+    describe("when the caller is not the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = operator;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be methodologist");
+      });
+    });
+  });
+
+  describe("#replaceProtectedModule", () => {
+    let subjectOldModule: Address;
+    let subjectNewModule: Address;
+    let subjectOldExtension: Address;
+    let subjectNewExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      await setV2Setup.controller.addModule(otherAccount.address);
+
+      subjectCaller = operator;
+      subjectOldModule = setV2Setup.streamingFeeModule.address;
+      subjectNewModule = otherAccount.address;
+      subjectOldExtension = baseExtension.address;
+      subjectNewExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager
+        .connect(caller.wallet)
+        .replaceProtectedModule(subjectOldModule, subjectNewModule, [subjectNewExtension]);
+    }
+
+    describe("when old module is protected", () => {
+      beforeEach(async () => {
+        await baseManager.connect(operator.wallet).protectModule(subjectOldModule, [subjectOldExtension]);
+      });
+
+      describe("when new module is not added", () => {
+        it("should add new module to setToken", async () => {
+          const initialModuleAdded = await setToken.isPendingModule(subjectNewModule);
+
+          await subject(operator);
+          await subject(methodologist);
+
+          const finalModuleAdded = await setToken.isPendingModule(subjectNewModule);
+
+          expect(initialModuleAdded).to.be.false;
+          expect(finalModuleAdded).to.be.true;
+        });
+
+        it("should remove old module from setToken", async () => {
+          const initialModuleAdded = await setToken.isInitializedModule(subjectOldModule);
+
+          await subject(operator);
+          await subject(methodologist);
+
+          const finalModuleAdded = await setToken.isInitializedModule(subjectOldModule);
+
+          expect(initialModuleAdded).to.be.true;
+          expect(finalModuleAdded).to.be.false;
+        });
+
+        it("should protect the module", async () => {
+          const initialIsProtected = await baseManager.protectedModules(subjectNewModule);
+          const initialProtectedModulesList = await baseManager.getProtectedModules();
+
+          await subject(operator);
+          await subject(methodologist);
+
+          const finalIsProtected = await baseManager.protectedModules(subjectNewModule);
+          const finalProtectedModulesList = await baseManager.getProtectedModules();
+
+          expect(initialIsProtected).to.be.false;
+          expect(finalIsProtected).to.be.true;
+          expect(initialProtectedModulesList[0]).equals(subjectOldModule);
+          expect(finalProtectedModulesList[0]).equals(subjectNewModule);
+        });
+
+        it("should unprotect the old module", async () => {
+          await subject(operator);
+          await subject(methodologist);
+
+          const isProtected = await baseManager.protectedModules(subjectOldModule);
+          expect(isProtected).to.be.false;
+        });
+
+        it("should clear the old modules authorized extension registries", async () => {
+          const initialAuthorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectOldModule);
+          const initialIsAuthorized = await baseManager.isAuthorizedExtension(subjectOldModule, subjectOldExtension);
+
+          await subject(operator);
+          await subject(methodologist);
+
+          const finalAuthorizedExtensionsList = await baseManager.getAuthorizedExtensions(subjectOldModule);
+          const finalIsAuthorized = await baseManager.isAuthorizedExtension(subjectOldModule, subjectOldExtension);
+
+          expect(initialAuthorizedExtensionsList.length).equals(1);
+          expect(initialIsAuthorized).to.be.true;
+          expect(finalAuthorizedExtensionsList.length).equals(0);
+          expect(finalIsAuthorized).to.be.false;
+        });
+
+        it("should add and authorize the new module extension", async () => {
+          const initialIsExtension = await baseManager.isExtension(subjectNewExtension);
+          const initialIsAuthorizedExtension = await baseManager.isAuthorizedExtension(
+            subjectNewModule, subjectNewExtension
+          );
+
+          await subject(operator);
+          await subject(methodologist);
+
+          const finalIsExtension = await baseManager.isExtension(subjectNewExtension);
+          const finalIsAuthorizedExtension = await baseManager.isAuthorizedExtension(
+            subjectNewModule,
+            subjectNewExtension
+          );
+
+          expect(initialIsExtension).to.be.false;
+          expect(finalIsExtension).to.be.true;
+          expect(initialIsAuthorizedExtension).to.be.false;
+          expect(finalIsAuthorizedExtension).to.be.true;
+        });
+
+        it("should emit the correct ReplacedProtectedModule event", async () => {
+          await subject(operator);
+
+          await expect(subject(methodologist)).to
+            .emit(baseManager, "ReplacedProtectedModule")
+            .withArgs(subjectOldModule, subjectNewModule, [subjectNewExtension]);
+        });
+      });
+
+      describe("when the new module is already added", async () => {
+        beforeEach(async () => {
+          await baseManager.addModule(subjectNewModule);
+        });
+
+        it("should revert", async () => {
+          await subject(operator);
+          await expect(subject(methodologist)).to.be.revertedWith("Module must not be added");
+        });
+      });
+    });
+
+    describe("when old module is not protected", () => {
+      it("should revert", async () => {
+        await subject(operator);
+        await expect(subject(methodologist)).to.be.revertedWith("Module not protected");
+      });
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
+  });
+
+  describe("#emergencyReplaceProtectedModule", () => {
+    let subjectOldModule: Address;
+    let subjectAdditionalOldModule: Address;
+    let subjectNewModule: Address;
+    let subjectNewExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      await setV2Setup.controller.addModule(otherAccount.address);
+
+      subjectCaller = operator;
+      subjectOldModule = setV2Setup.streamingFeeModule.address;
+      subjectAdditionalOldModule = setV2Setup.governanceModule.address; // Removable
+      subjectNewModule = otherAccount.address;
+      subjectNewExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+    });
+
+    async function subject(caller: Account): Promise<any> {
+      return baseManager
+        .connect(caller.wallet)
+        .emergencyReplaceProtectedModule(subjectNewModule, [subjectNewExtension]);
+    }
+
+    describe("when new module is not added", () => {
+      beforeEach(async () => {
+        // Trigger emergency
+        baseManager.connect(operator.wallet);
+        await baseManager.protectModule(subjectOldModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectOldModule);
+      });
+
+      it("should add module to setToken", async () => {
+        const initialModuleAdded = await setToken.isPendingModule(subjectNewModule);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalModuleAdded = await setToken.isPendingModule(subjectNewModule);
+
+        expect(initialModuleAdded).to.be.false;
+        expect(finalModuleAdded).to.be.true;
+      });
+
+      it("should protect the module", async () => {
+        const initialIsProtected = await baseManager.protectedModules(subjectNewModule);
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalIsProtected = await baseManager.protectedModules(subjectNewModule);
+
+        expect(initialIsProtected).to.be.false;
+        expect(finalIsProtected).to.be.true;
+      });
+
+      it("should add and authorize the new module extension", async () => {
+        const initialIsExtension = await baseManager.isExtension(subjectNewExtension);
+        const initialIsAuthorizedExtension = await baseManager.isAuthorizedExtension(
+          subjectNewModule, subjectNewExtension
+        );
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalIsExtension = await baseManager.isExtension(subjectNewExtension);
+        const finalIsAuthorizedExtension = await baseManager.isAuthorizedExtension(
+          subjectNewModule,
+          subjectNewExtension
+        );
+
+        expect(initialIsExtension).to.be.false;
+        expect(finalIsExtension).to.be.true;
+        expect(initialIsAuthorizedExtension).to.be.false;
+        expect(finalIsAuthorizedExtension).to.be.true;
+      });
+
+      it("should decrement the emergencies counter", async() => {
+        const initialEmergencies = await baseManager.emergencies();
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalEmergencies = await baseManager.emergencies();
+
+        expect(initialEmergencies.toNumber()).equals(1);
+        expect(finalEmergencies.toNumber()).equals(0);
+      });
+
+      it("should emit the correct EmergencyReplacedProtectedModule event", async () => {
+        await subject(operator);
+
+        await expect(subject(methodologist)).to
+          .emit(baseManager, "EmergencyReplacedProtectedModule")
+          .withArgs(subjectNewModule, [subjectNewExtension]);
+      });
+    });
+
+    describe("when the new module is already added", async () => {
+      beforeEach(async () => {
+        baseManager.connect(operator.wallet);
+        await baseManager.addModule(subjectNewModule);
+        await baseManager.protectModule(subjectOldModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectOldModule);
+      });
+
+      it("should revert", async () => {
+        await subject(operator);
+        await expect(subject(methodologist)).to.be.revertedWith("Module must not be added");
+      });
+    });
+
+    describe("when an emergency is not in progress", async () => {
+      it("should revert", async () => {
+        await subject(operator);
+        await expect(subject(methodologist)).to.be.revertedWith("Not in emergency");
+      });
+    });
+
+    describe("when more than one emergency is in progress", async () => {
+      beforeEach(async () => {
+        baseManager.connect(operator.wallet);
+        await baseManager.protectModule(subjectOldModule, []);
+        await baseManager.protectModule(subjectAdditionalOldModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectOldModule);
+        await baseManager.emergencyRemoveProtectedModule(subjectAdditionalOldModule);
+      });
+
+      it("should remain in an emergency state after replacement", async () => {
+        const initialEmergencies = await baseManager.emergencies();
+
+        await subject(operator);
+        await subject(methodologist);
+
+        const finalEmergencies = await baseManager.emergencies();
+
+        expect(initialEmergencies.toNumber()).equals(2);
+        expect(finalEmergencies.toNumber()).equals(1);
+      });
+    });
+
+    describe("when a single mutual upgrade party calls", () => {
+      it("should log the proposed streaming fee hash in the mutualUpgrades mapping", async () => {
+        const txHash = await subject(operator);
+        await validateMutualUprade(txHash, operator.address);
+      });
+    });
+
+    describe("when the caller is not the operator or methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject(subjectCaller)).to.be.revertedWith("Must be authorized");
+      });
+    });
+  });
+
+  describe("#resolveEmergency", () => {
+    let subjectModule: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectCaller = methodologist;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).resolveEmergency();
+    }
+
+    describe("when an emergency is in progress", () => {
+      beforeEach(async () => {
+        await baseManager.protectModule(subjectModule, []);
+        await baseManager.emergencyRemoveProtectedModule(subjectModule);
+      });
+
+      it("should decrement the emergency counter", async () => {
+        const initialEmergencies = await baseManager.emergencies();
+
+        await subject();
+
+        const finalEmergencies = await baseManager.emergencies();
+
+        expect(initialEmergencies.toNumber()).equals(1);
+        expect(finalEmergencies.toNumber()).equals(0);
+      });
+    });
+
+    describe("when an emergency is *not* in progress", async () => {
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Not in emergency");
+      });
+    });
+
+    describe("when the caller is not the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = operator;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be methodologist");
+      });
+    });
+  });
+
+  describe("#interactManager", async () => {
+    let subjectModule: Address;
+    let subjectExtension: Address;
+    let subjectCallData: Bytes;
+
+    beforeEach(async () => {
+      await baseManager.connect(operator.wallet).addExtension(baseExtension.address);
+
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectExtension = baseExtension.address;
+
+      // Invoke update fee recipient
+      subjectCallData = setV2Setup.streamingFeeModule.interface.encodeFunctionData("updateFeeRecipient", [
+        setToken.address,
+        otherAccount.address,
+      ]);
+    });
+
+    async function subject(): Promise<any> {
+      return baseExtension.interactManager(subjectModule, subjectCallData);
+    }
+
+    context("when the manager is initialized", () => {
+      beforeEach(async() => {
+        await baseManager.connect(methodologist.wallet).authorizeInitialization();
+      });
+
+      it("should call updateFeeRecipient on the streaming fee module from the SetToken", async () => {
+        await subject();
+        const feeStates = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
+        expect(feeStates.feeRecipient).to.eq(otherAccount.address);
+      });
+
+      describe("when the caller is not an extension", async () => {
+        beforeEach(async () => {
+          await baseManager.connect(operator.wallet).removeExtension(baseExtension.address);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("Must be extension");
+        });
+      });
+    });
+
+    context("when the manager is not initialized", () => {
+      it("updateFeeRecipient should revert", async () => {
+        expect(subject()).to.be.revertedWith("Manager not initialized");
+      });
+    });
+
+    context("when the module is protected and extension is authorized", () => {
+      beforeEach(async () => {
+        await baseManager.connect(methodologist.wallet).authorizeInitialization();
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("updateFeeRecipient should succeed", async () => {
+        await subject();
+        const feeStates = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
+        expect(feeStates.feeRecipient).to.eq(otherAccount.address);
+      });
+    });
+
+    context("when the module is protected and extension is not authorized", () => {
+      beforeEach(async () => {
+        await baseManager.connect(methodologist.wallet).authorizeInitialization();
+        await baseManager.connect(operator.wallet).protectModule(subjectModule, []);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Extension not authorized for module");
+      });
+    });
+  });
+
+  describe("#removeModule", async () => {
+    let subjectModule: Address;
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectExtension = baseExtension.address;
+      subjectCaller = operator;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).removeModule(subjectModule);
+    }
+
+    it("should remove the module from the SetToken", async () => {
+      await subject();
+      const isModule = await setToken.isInitializedModule(subjectModule);
+      expect(isModule).to.eq(false);
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+
+    describe("when the module is protected module", () => {
+      beforeEach(() => {
+        baseManager.connect(operator.wallet).protectModule(subjectModule, [subjectExtension]);
+      });
+
+      it("should revert", async() => {
+        await expect(subject()).to.be.revertedWith("Module protected");
+      });
+    });
+  });
+
+  describe("#setMethodologist", async () => {
+    let subjectNewMethodologist: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectNewMethodologist = await getRandomAddress();
+      subjectCaller = methodologist;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).setMethodologist(subjectNewMethodologist);
+    }
+
+    it("should set the new methodologist", async () => {
+      await subject();
+      const actualIndexModule = await baseManager.methodologist();
+      expect(actualIndexModule).to.eq(subjectNewMethodologist);
+    });
+
+    it("should emit the correct MethodologistChanged event", async () => {
+      await expect(subject()).to.emit(baseManager, "MethodologistChanged").withArgs(methodologist.address, subjectNewMethodologist);
+    });
+
+    describe("when the caller is not the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be methodologist");
+      });
+    });
+  });
+
+  describe("#setOperator", async () => {
+    let subjectNewOperator: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectNewOperator = await getRandomAddress();
+      subjectCaller = operator;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).setOperator(subjectNewOperator);
+    }
+
+    it("should set the new operator", async () => {
+      await subject();
+      const actualIndexModule = await baseManager.operator();
+      expect(actualIndexModule).to.eq(subjectNewOperator);
+    });
+
+    it("should emit the correct OperatorChanged event", async () => {
+      await expect(subject()).to.emit(baseManager, "OperatorChanged").withArgs(operator.address, subjectNewOperator);
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+});

--- a/test/manager/baseManagerV2.spec.ts
+++ b/test/manager/baseManagerV2.spec.ts
@@ -18,7 +18,7 @@ import { SetFixture } from "@utils/fixtures";
 
 import { solidityKeccak256 } from "ethers/lib/utils";
 import { ContractTransaction } from "ethers";
-import { BigNumber } from "@ethersproject/BigNumber";
+import { BigNumber } from "@ethersproject/bignumber";
 
 const expect = getWaffleExpect();
 

--- a/test/manager/baseManagerV2.spec.ts
+++ b/test/manager/baseManagerV2.spec.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { Address, Account, Bytes } from "@utils/types";
 import { ADDRESS_ZERO, ZERO } from "@utils/constants";
-import { BaseManagerV2, BaseAdapterMock } from "@utils/contracts/index";
+import { BaseManagerV2, BaseExtensionMock } from "@utils/contracts/index";
 import { SetToken } from "@utils/contracts/setV2";
 import DeployHelper from "@utils/deploys";
 import {
@@ -32,7 +32,7 @@ describe("BaseManagerV2", () => {
   let setToken: SetToken;
 
   let baseManager: BaseManagerV2;
-  let baseExtension: BaseAdapterMock;
+  let baseExtension: BaseExtensionMock;
 
   async function validateMutualUprade(txHash: ContractTransaction, caller: Address) {
     const expectedHash = solidityKeccak256(["bytes", "address"], [txHash.data, caller]);
@@ -90,7 +90,7 @@ describe("BaseManagerV2", () => {
     // Transfer operatorship to BaseManager
     await setToken.setManager(baseManager.address);
 
-    baseExtension = await deployer.mocks.deployBaseAdapterMock(baseManager.address);
+    baseExtension = await deployer.mocks.deployBaseExtensionMock(baseManager.address);
   });
 
   addSnapshotBeforeRestoreAfterEach();
@@ -187,7 +187,7 @@ describe("BaseManagerV2", () => {
 
     describe("protectedModules: single, with multiple extension", () => {
       beforeEach(async () => {
-        subjectAdditionalExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+        subjectAdditionalExtension = (await deployer.mocks.deployBaseExtensionMock(baseManager.address)).address;
         subjectProtectedModules = [subjectModule];
         subjectAuthorizedExtensions = [[subjectExtension, subjectAdditionalExtension]];
       });
@@ -225,7 +225,7 @@ describe("BaseManagerV2", () => {
 
     describe("protectedModules: multiple, with extensions", () => {
       beforeEach(async () => {
-        subjectAdditionalExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+        subjectAdditionalExtension = (await deployer.mocks.deployBaseExtensionMock(baseManager.address)).address;
         subjectProtectedModules = [subjectModule, subjectAdditionalModule];
         subjectAuthorizedExtensions = [ [subjectExtension], [subjectAdditionalExtension] ];
       });
@@ -410,7 +410,7 @@ describe("BaseManagerV2", () => {
 
     describe("when extension has different manager address", async () => {
       beforeEach(async () => {
-        subjectExtension = (await deployer.mocks.deployBaseAdapterMock(await getRandomAddress())).address;
+        subjectExtension = (await deployer.mocks.deployBaseExtensionMock(await getRandomAddress())).address;
       });
 
       it("should revert", async () => {
@@ -454,7 +454,7 @@ describe("BaseManagerV2", () => {
       subjectModule = setV2Setup.streamingFeeModule.address;
       subjectAdditionalModule = setV2Setup.issuanceModule.address;
       subjectExtension = baseExtension.address;
-      subjectAdditionalExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+      subjectAdditionalExtension = (await deployer.mocks.deployBaseExtensionMock(baseManager.address)).address;
       subjectCaller = operator;
     });
 
@@ -1171,7 +1171,7 @@ describe("BaseManagerV2", () => {
       subjectOldModule = setV2Setup.streamingFeeModule.address;
       subjectNewModule = otherAccount.address;
       subjectOldExtension = baseExtension.address;
-      subjectNewExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+      subjectNewExtension = (await deployer.mocks.deployBaseExtensionMock(baseManager.address)).address;
     });
 
     async function subject(caller: Account): Promise<any> {
@@ -1331,7 +1331,7 @@ describe("BaseManagerV2", () => {
       subjectOldModule = setV2Setup.streamingFeeModule.address;
       subjectAdditionalOldModule = setV2Setup.governanceModule.address; // Removable
       subjectNewModule = otherAccount.address;
-      subjectNewExtension = (await deployer.mocks.deployBaseAdapterMock(baseManager.address)).address;
+      subjectNewExtension = (await deployer.mocks.deployBaseExtensionMock(baseManager.address)).address;
     });
 
     async function subject(caller: Account): Promise<any> {

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -2,6 +2,7 @@ export { BaseExtensionMock } from "../../typechain/BaseExtensionMock";
 export { BaseManager } from "../../typechain/BaseManager";
 export { BaseManagerV2 } from "../../typechain/BaseManagerV2";
 export { ChainlinkAggregatorV3Mock } from "../../typechain/ChainlinkAggregatorV3Mock";
+export { DebtIssuanceModule } from "../../typechain/DebtIssuanceModule";
 export { ExchangeIssuance } from "../../typechain/ExchangeIssuance";
 export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
 export { FeeSplitExtension } from "../../typechain/FeeSplitExtension";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -1,4 +1,4 @@
-export { BaseAdapterMock } from "../../typechain/BaseAdapterMock";
+export { BaseExtensionMock } from "../../typechain/BaseExtensionMock";
 export { BaseManager } from "../../typechain/BaseManager";
 export { BaseManagerV2 } from "../../typechain/BaseManagerV2";
 export { ChainlinkAggregatorV3Mock } from "../../typechain/ChainlinkAggregatorV3Mock";
@@ -7,7 +7,7 @@ export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
 export { FeeSplitExtension } from "../../typechain/FeeSplitExtension";
 export { FlexibleLeverageStrategyExtension } from "../../typechain/FlexibleLeverageStrategyExtension";
 export { GIMExtension } from "../../typechain/GIMExtension";
-export { GovernanceAdapter } from "../../typechain/GovernanceAdapter";
+export { GovernanceExtension } from "../../typechain/GovernanceExtension";
 export { GovernanceAdapterMock } from "../../typechain/GovernanceAdapterMock";
 export { ICManager } from "../../typechain/ICManager";
 export { IndexToken } from "../../typechain/IndexToken";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -1,5 +1,6 @@
 export { BaseAdapterMock } from "../../typechain/BaseAdapterMock";
 export { BaseManager } from "../../typechain/BaseManager";
+export { BaseManagerV2 } from "../../typechain/BaseManagerV2";
 export { ChainlinkAggregatorV3Mock } from "../../typechain/ChainlinkAggregatorV3Mock";
 export { ExchangeIssuance } from "../../typechain/ExchangeIssuance";
 export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
@@ -25,3 +26,4 @@ export { TradeAdapterMock } from "../../typechain/TradeAdapterMock";
 export { Vesting } from "../../typechain/Vesting";
 export { WETH9 } from "../../typechain/WETH9";
 export { FLIStrategyExtensionMock } from "../../typechain/FLIStrategyExtensionMock";
+

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -18,6 +18,7 @@ export { RewardsDistributionRecipient } from "../../typechain/RewardsDistributio
 export { StakingRewards } from "../../typechain/StakingRewards";
 export { StakingRewardsV2 } from "../../typechain/StakingRewardsV2";
 export { StandardTokenMock } from "../../typechain/StandardTokenMock";
+export { StreamingFeeModule } from "../../typechain/StreamingFeeModule";
 export { StreamingFeeSplitExtension } from "../../typechain/StreamingFeeSplitExtension";
 export { StringArrayUtilsMock } from "../../typechain/StringArrayUtilsMock";
 export { SupplyCapAllowedCallerIssuanceHook } from "../../typechain/SupplyCapAllowedCallerIssuanceHook";

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -4,7 +4,7 @@ export { BaseManagerV2 } from "../../typechain/BaseManagerV2";
 export { ChainlinkAggregatorV3Mock } from "../../typechain/ChainlinkAggregatorV3Mock";
 export { ExchangeIssuance } from "../../typechain/ExchangeIssuance";
 export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
-export { FeeSplitAdapter } from "../../typechain/FeeSplitAdapter";
+export { FeeSplitExtension } from "../../typechain/FeeSplitExtension";
 export { FlexibleLeverageStrategyExtension } from "../../typechain/FlexibleLeverageStrategyExtension";
 export { GIMExtension } from "../../typechain/GIMExtension";
 export { GovernanceAdapter } from "../../typechain/GovernanceAdapter";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -43,11 +43,13 @@ export default class DeployAdapters {
     manager: Address,
     streamingFeeModule: Address,
     operatorFeeSplit: BigNumber,
+    operatorFeeRecipient: Address,
   ): Promise<StreamingFeeSplitExtension> {
     return await new StreamingFeeSplitExtension__factory(this._deployerSigner).deploy(
       manager,
       streamingFeeModule,
-      operatorFeeSplit
+      operatorFeeSplit,
+      operatorFeeRecipient
     );
   }
 

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -4,7 +4,7 @@ import {
   ExchangeIssuance,
   ExchangeIssuanceV2,
   FlexibleLeverageStrategyExtension,
-  FeeSplitAdapter,
+  FeeSplitExtension,
   GIMExtension,
   GovernanceAdapter,
   StreamingFeeSplitExtension
@@ -12,7 +12,7 @@ import {
 
 import { ExchangeIssuance__factory } from "../../typechain/factories/ExchangeIssuance__factory";
 import { ExchangeIssuanceV2__factory } from "../../typechain/factories/ExchangeIssuanceV2__factory";
-import { FeeSplitAdapter__factory } from "../../typechain/factories/FeeSplitAdapter__factory";
+import { FeeSplitExtension__factory } from "../../typechain/factories/FeeSplitExtension__factory";
 import { FlexibleLeverageStrategyExtension__factory } from "../../typechain/factories/FlexibleLeverageStrategyExtension__factory";
 import { GIMExtension__factory } from "../../typechain/factories/GIMExtension__factory";
 import { GovernanceAdapter__factory } from "../../typechain/factories/GovernanceAdapter__factory";
@@ -25,14 +25,14 @@ export default class DeployAdapters {
     this._deployerSigner = deployerSigner;
   }
 
-  public async deployFeeSplitAdapter(
+  public async deployFeeSplitExtension(
     manager: Address,
     streamingFeeModule: Address,
     debtIssuanceModule: Address,
     operatorFeeSplit: BigNumber,
     operatorFeeRecipient: Address
-  ): Promise<FeeSplitAdapter> {
-    return await new FeeSplitAdapter__factory(this._deployerSigner).deploy(
+  ): Promise<FeeSplitExtension> {
+    return await new FeeSplitExtension__factory(this._deployerSigner).deploy(
       manager,
       streamingFeeModule,
       debtIssuanceModule,

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -30,12 +30,14 @@ export default class DeployAdapters {
     streamingFeeModule: Address,
     debtIssuanceModule: Address,
     operatorFeeSplit: BigNumber,
+    operatorFeeRecipient: Address
   ): Promise<FeeSplitAdapter> {
     return await new FeeSplitAdapter__factory(this._deployerSigner).deploy(
       manager,
       streamingFeeModule,
       debtIssuanceModule,
-      operatorFeeSplit
+      operatorFeeSplit,
+      operatorFeeRecipient
     );
   }
 

--- a/utils/deploys/deployExtensions.ts
+++ b/utils/deploys/deployExtensions.ts
@@ -6,7 +6,7 @@ import {
   FlexibleLeverageStrategyExtension,
   FeeSplitExtension,
   GIMExtension,
-  GovernanceAdapter,
+  GovernanceExtension,
   StreamingFeeSplitExtension
 } from "../contracts/index";
 
@@ -15,10 +15,10 @@ import { ExchangeIssuanceV2__factory } from "../../typechain/factories/ExchangeI
 import { FeeSplitExtension__factory } from "../../typechain/factories/FeeSplitExtension__factory";
 import { FlexibleLeverageStrategyExtension__factory } from "../../typechain/factories/FlexibleLeverageStrategyExtension__factory";
 import { GIMExtension__factory } from "../../typechain/factories/GIMExtension__factory";
-import { GovernanceAdapter__factory } from "../../typechain/factories/GovernanceAdapter__factory";
+import { GovernanceExtension__factory } from "../../typechain/factories/GovernanceExtension__factory";
 import { StreamingFeeSplitExtension__factory } from "../../typechain/factories/StreamingFeeSplitExtension__factory";
 
-export default class DeployAdapters {
+export default class DeployExtensions {
   private _deployerSigner: Signer;
 
   constructor(deployerSigner: Signer) {
@@ -55,11 +55,11 @@ export default class DeployAdapters {
     );
   }
 
-  public async deployGovernanceAdapter(
+  public async deployGovernanceExtension(
     manager: Address,
     governanceModule: Address,
-  ): Promise<GovernanceAdapter> {
-    return await new GovernanceAdapter__factory(this._deployerSigner).deploy(
+  ): Promise<GovernanceExtension> {
+    return await new GovernanceExtension__factory(this._deployerSigner).deploy(
       manager,
       governanceModule
     );

--- a/utils/deploys/deployManager.ts
+++ b/utils/deploys/deployManager.ts
@@ -35,11 +35,15 @@ export default class DeployToken {
     set: Address,
     operator: Address,
     methodologist: Address,
+    protectedModules: Address[],
+    authorizedExtensions: Address[][]
   ): Promise<BaseManager> {
     return await new BaseManager__factory(this._deployerSigner).deploy(
       set,
       operator,
       methodologist,
+      protectedModules,
+      authorizedExtensions
     );
   }
 }

--- a/utils/deploys/deployManager.ts
+++ b/utils/deploys/deployManager.ts
@@ -1,10 +1,11 @@
 import { Signer } from "ethers";
 import { BigNumber } from "@ethersproject/bignumber";
 import { Address } from "../types";
-import { ICManager, BaseManager } from "../contracts/index";
+import { ICManager, BaseManager, BaseManagerV2 } from "../contracts/index";
 
 import { ICManager__factory } from "../../typechain/factories/ICManager__factory";
 import { BaseManager__factory } from "../../typechain/factories/BaseManager__factory";
+import { BaseManagerV2__factory } from "../../typechain/factories/BaseManagerV2__factory";
 
 export default class DeployToken {
   private _deployerSigner: Signer;
@@ -34,11 +35,23 @@ export default class DeployToken {
   public async deployBaseManager(
     set: Address,
     operator: Address,
+    methodologist: Address
+  ): Promise<BaseManager> {
+    return await new BaseManager__factory(this._deployerSigner).deploy(
+      set,
+      operator,
+      methodologist
+    );
+  }
+
+  public async deployBaseManagerV2(
+    set: Address,
+    operator: Address,
     methodologist: Address,
     protectedModules: Address[],
     authorizedExtensions: Address[][]
-  ): Promise<BaseManager> {
-    return await new BaseManager__factory(this._deployerSigner).deploy(
+  ): Promise<BaseManagerV2> {
+    return await new BaseManagerV2__factory(this._deployerSigner).deploy(
       set,
       operator,
       methodologist,

--- a/utils/deploys/deployManager.ts
+++ b/utils/deploys/deployManager.ts
@@ -47,16 +47,12 @@ export default class DeployToken {
   public async deployBaseManagerV2(
     set: Address,
     operator: Address,
-    methodologist: Address,
-    protectedModules: Address[],
-    authorizedExtensions: Address[][]
+    methodologist: Address
   ): Promise<BaseManagerV2> {
     return await new BaseManagerV2__factory(this._deployerSigner).deploy(
       set,
       operator,
-      methodologist,
-      protectedModules,
-      authorizedExtensions
+      methodologist
     );
   }
 }

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -1,7 +1,7 @@
 import { Signer, BigNumber } from "ethers";
 import { Address } from "../types";
 import {
-  BaseAdapterMock,
+  BaseExtensionMock,
   FLIStrategyExtensionMock,
   GovernanceAdapterMock,
   MutualUpgradeMock,
@@ -10,7 +10,7 @@ import {
   TradeAdapterMock
 } from "../contracts/index";
 
-import { BaseAdapterMock__factory } from "../../typechain/factories/BaseAdapterMock__factory";
+import { BaseExtensionMock__factory } from "../../typechain/factories/BaseExtensionMock__factory";
 import { ChainlinkAggregatorV3Mock__factory  } from "../../typechain/factories/ChainlinkAggregatorV3Mock__factory";
 import { FLIStrategyExtensionMock__factory } from "../../typechain/factories/FLIStrategyExtensionMock__factory";
 import { GovernanceAdapterMock__factory  } from "../../typechain/factories/GovernanceAdapterMock__factory";
@@ -27,8 +27,8 @@ export default class DeployMocks {
     this._deployerSigner = deployerSigner;
   }
 
-  public async deployBaseAdapterMock(manager: Address): Promise<BaseAdapterMock> {
-    return await new BaseAdapterMock__factory(this._deployerSigner).deploy(manager);
+  public async deployBaseExtensionMock(manager: Address): Promise<BaseExtensionMock> {
+    return await new BaseExtensionMock__factory(this._deployerSigner).deploy(manager);
   }
 
   public async deployTradeAdapterMock(): Promise<TradeAdapterMock> {

--- a/utils/deploys/index.ts
+++ b/utils/deploys/index.ts
@@ -4,7 +4,7 @@ import DeployManager from "./deployManager";
 import DeployMocks from "./deployMocks";
 import DeployToken from "./deployToken";
 import DeploySetV2 from "./deploySetV2";
-import DeployAdapter from "./deployAdapters";
+import DeployExtensions from "./deployExtensions";
 import DeployExternalContracts from "./deployExternal";
 import DeployHooks from "./deployHooks";
 import DeployStaking from "./deployStaking";
@@ -15,7 +15,7 @@ export default class DeployHelper {
   public setV2: DeploySetV2;
   public manager: DeployManager;
   public mocks: DeployMocks;
-  public adapters: DeployAdapter;
+  public extensions: DeployExtensions;
   public external: DeployExternalContracts;
   public hooks: DeployHooks;
   public staking: DeployStaking;
@@ -26,7 +26,7 @@ export default class DeployHelper {
     this.setV2 = new DeploySetV2(deployerSigner);
     this.manager = new DeployManager(deployerSigner);
     this.mocks = new DeployMocks(deployerSigner);
-    this.adapters = new DeployAdapter(deployerSigner);
+    this.extensions = new DeployExtensions(deployerSigner);
     this.external = new DeployExternalContracts(deployerSigner);
     this.hooks = new DeployHooks(deployerSigner);
     this.staking = new DeployStaking(deployerSigner);


### PR DESCRIPTION
PR implements 
+ [IIP-64: Methodologist Smart Contract Permissioning][22]
+ [IIP-72: Redirect FLI Revenue to Operations Account][25]

[22]: https://gov.indexcoop.com/t/iip-64-methodologist-smart-contract-permissioning/2200/2
[25]: https://gov.indexcoop.com/t/iip-72-redirect-fli-revenue-to-operations-account/2368

**Summary**
+ Makes fee, fee split and fee recipient updates `mutualUpgrade` in existing fee extension contracts
+ Makes fee extension address the default `feeRecipient` to firewall fees from other extensions.
+ Adds methods to guarantee that operator cannot unilaterally change fee arrangements.

**New Permissions**

The permissions model proposed here has the following properties:
+ supports a registry of protected modules and defines which extensions may call them
+ protected modules are configured after deployment before the contract is enabled
+ the methodologist must enable the manager contract before it can begin operation
+ updates to protected module arrangements can only be performed by mutual upgrade, except under emergency conditions
+ protected modules cannot be unilaterally removed, except under emergency circumstances
+ extensions authorized for protected modules cannot be unilaterally removed, except under emergency conditions
+ the operator can protect new modules at their discretion, on behalf of the methodologist
+ the methodologist can un-protect modules at their discretion, on behalf of the operator  

**TODO**
- [x] Debug remaining skipped tests
- [x] Events tests
- [x] Update spec with new getters
- [x] Add method to allow operator to set an address which will receive its fees. 
  + [IIP-72][10]
  + (StreamingFeeSplitExtension) fe959c5
  + (FeeSplitAdapter) aa126c4
- [x] Resolve accrual protection design questions
- [x] Format as new manager contract, renaming adapter as extension. 
- [x] Fixes for second review sweep

**Open Questions**

Have retained the "adapter" naming convention to reduce noise in the diff. This PR might be the right time to rename everything `extension`?

There's an asymmetry in the preconditions for replacing modules vs. protecting them. 
  + Replacing a module adds and removes from the SetToken, meaning the replacement cannot already be added
  + Protecting a module (operator only) requires that the module already be added. 

The idea behind this is that in the "replacement" scenario, we don't really want the operator to double-up fee modules - it's cleaner to model as an atomic swap. In the "protect" scenario, the operator is adding new features and should have more flexibility. Does this make sense? Or should behavior in these two scenarios be standardized?

[10]: https://gov.indexcoop.com/t/iip-72-redirect-fli-revenue-to-operations-account/2368
  