### PR TITLE
Fix Solidity warnings

### DIFF
--- a/contracts/adapters/FeeSplitExtension.sol
+++ b/contracts/adapters/FeeSplitExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/adapters/FlexibleLeverageStrategyExtension.sol
+++ b/contracts/adapters/FlexibleLeverageStrategyExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/adapters/GIMExtension.sol
+++ b/contracts/adapters/GIMExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/adapters/GovernanceExtension.sol
+++ b/contracts/adapters/GovernanceExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/adapters/StreamingFeeSplitExtension.sol
+++ b/contracts/adapters/StreamingFeeSplitExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/hooks/SupplyCapAllowedCallerIssuanceHook.sol
+++ b/contracts/hooks/SupplyCapAllowedCallerIssuanceHook.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;
@@ -42,7 +44,7 @@ contract SupplyCapAllowedCallerIssuanceHook is Ownable, IManagerIssuanceHook {
     event SupplyCapUpdated(uint256 _newCap);
     event CallerStatusUpdated(address indexed _caller, bool _status);
     event AnyoneCallableUpdated(bool indexed _status);
-    
+
     /* ============ State Variables ============ */
 
     // Cap on totalSupply of Sets
@@ -89,7 +91,7 @@ contract SupplyCapAllowedCallerIssuanceHook is Ownable, IManagerIssuanceHook {
         override
     {
         _validateAllowedContractCaller(_sender);
-        
+
         uint256 totalSupply = _setToken.totalSupply();
         require(totalSupply.add(_issueQuantity) <= supplyCap, "Supply cap exceeded");
     }
@@ -133,7 +135,7 @@ contract SupplyCapAllowedCallerIssuanceHook is Ownable, IManagerIssuanceHook {
     }
 
     /**
-     * ONLY OWNER: Toggle whether anyone can call function, bypassing the callAllowlist 
+     * ONLY OWNER: Toggle whether anyone can call function, bypassing the callAllowlist
      *
      * @param _status           Boolean indicating whether to allow anyone call
      */
@@ -145,7 +147,7 @@ contract SupplyCapAllowedCallerIssuanceHook is Ownable, IManagerIssuanceHook {
     /* ============ Internal Functions ============ */
 
     /**
-     * Validate if passed address is allowed to call function. If anyoneCallable is set to true, anyone can call otherwise needs to be an EOA or 
+     * Validate if passed address is allowed to call function. If anyoneCallable is set to true, anyone can call otherwise needs to be an EOA or
      * approved contract address.
      */
     function _validateAllowedContractCaller(address _caller) internal view {

--- a/contracts/hooks/SupplyCapIssuanceHook.sol
+++ b/contracts/hooks/SupplyCapIssuanceHook.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;
@@ -36,7 +38,7 @@ contract SupplyCapIssuanceHook is Ownable, IManagerIssuanceHook {
     /* ============ Events ============ */
 
     event SupplyCapUpdated(uint256 _newCap);
-    
+
     /* ============ State Variables ============ */
 
     // Cap on totalSupply of Sets

--- a/contracts/interfaces/IAdapter.sol
+++ b/contracts/interfaces/IAdapter.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/interfaces/IBaseManager.sol
+++ b/contracts/interfaces/IBaseManager.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/interfaces/ICErc20.sol
+++ b/contracts/interfaces/ICErc20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/interfaces/IChainlinkAggregatorV3.sol
+++ b/contracts/interfaces/IChainlinkAggregatorV3.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 interface IChainlinkAggregatorV3 {

--- a/contracts/interfaces/IComptroller.sol
+++ b/contracts/interfaces/IComptroller.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 

--- a/contracts/interfaces/IFLIStrategyExtension.sol
+++ b/contracts/interfaces/IFLIStrategyExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;
@@ -31,7 +33,7 @@ interface IFLIStrategyExtension {
 
     function getChunkRebalanceNotional(
         string[] calldata _exchangeNames
-    ) 
+    )
         external
         view
         returns(uint256[] memory sizes, address sellAsset, address buyAsset);

--- a/contracts/interfaces/IIndexModule.sol
+++ b/contracts/interfaces/IIndexModule.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/interfaces/ILeverageModule.sol
+++ b/contracts/interfaces/ILeverageModule.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/interfaces/IMasterChef.sol
+++ b/contracts/interfaces/IMasterChef.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 interface IMasterChef {

--- a/contracts/interfaces/IPair.sol
+++ b/contracts/interfaces/IPair.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 interface IPair {

--- a/contracts/interfaces/ISetToken.sol
+++ b/contracts/interfaces/ISetToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 pragma experimental "ABIEncoderV2";
 
@@ -39,13 +40,13 @@ interface ISetToken is IERC20 {
 
     /**
      * A struct that stores a component's cash position details and external positions
-     * This data structure allows O(1) access to a component's cash position units and 
+     * This data structure allows O(1) access to a component's cash position units and
      * virtual units.
      *
      * @param virtualUnit               Virtual value of a component's DEFAULT position. Stored as virtual for efficiency
      *                                  updating all units at once via the position multiplier. Virtual units are achieved
      *                                  by dividing a "real" value by the "positionMultiplier"
-     * @param componentIndex            
+     * @param componentIndex
      * @param externalPositionModules   List of external modules attached to each external position. Each module
      *                                  maps to an external position
      * @param externalPositions         Mapping of module => ExternalPosition struct for a given component
@@ -70,7 +71,7 @@ interface ISetToken is IERC20 {
 
 
     /* ============ Functions ============ */
-    
+
     function addComponent(address _component) external;
     function removeComponent(address _component) external;
     function editDefaultPositionUnit(address _component, int256 _realUnit) external;
@@ -98,7 +99,7 @@ interface ISetToken is IERC20 {
     function manager() external view returns (address);
     function moduleStates(address _module) external view returns (ModuleState);
     function getModules() external view returns (address[] memory);
-    
+
     function getDefaultPositionRealUnit(address _component) external view returns(int256);
     function getExternalPositionRealUnit(address _component, address _positionModule) external view returns(int256);
     function getComponents() external view returns(address[] memory);
@@ -106,7 +107,7 @@ interface ISetToken is IERC20 {
     function getExternalPositionData(address _component, address _positionModule) external view returns(bytes memory);
     function isExternalPositionModule(address _component, address _module) external view returns(bool);
     function isComponent(address _component) external view returns(bool);
-    
+
     function positionMultiplier() external view returns (int256);
     function getPositions() external view returns (Position[] memory);
     function getTotalComponentRealUnits(address _component) external view returns(int256);

--- a/contracts/interfaces/IStreamingFeeModule.sol
+++ b/contracts/interfaces/IStreamingFeeModule.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 pragma experimental "ABIEncoderV2";
 

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity >=0.6.10;
 
 interface IWETH {

--- a/contracts/lib/BaseExtension.sol
+++ b/contracts/lib/BaseExtension.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/lib/MutualUpgrade.sol
+++ b/contracts/lib/MutualUpgrade.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/lib/TimeLockUpgrade.sol
+++ b/contracts/lib/TimeLockUpgrade.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/manager/BaseManagerV2.sol
+++ b/contracts/manager/BaseManagerV2.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;

--- a/contracts/manager/ICManager.sol
+++ b/contracts/manager/ICManager.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity ^0.6.10;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
@@ -77,7 +78,7 @@ contract ICManager is TimeLockUpgrade, MutualUpgrade {
             _operatorFeeSplit <= PreciseUnitMath.preciseUnit(),
             "Operator Fee Split must be less than 1e18"
         );
-        
+
         setToken = _setToken;
         indexModule = _indexModule;
         feeModule = _feeModule;
@@ -160,7 +161,7 @@ contract ICManager is TimeLockUpgrade, MutualUpgrade {
     }
 
     /**
-     * OPERATOR ONLY: Toggle ability for passed addresses to trade from current state 
+     * OPERATOR ONLY: Toggle ability for passed addresses to trade from current state
      *
      * @param _traders           Array trader addresses to toggle status
      * @param _statuses          Booleans indicating if matching trader can trade
@@ -270,7 +271,7 @@ contract ICManager is TimeLockUpgrade, MutualUpgrade {
      *
      * @param _newFeeSplit           New fee split percentage
      */
-    function updateFeeSplit(uint256 _newFeeSplit) external mutualUpgrade(operator, methodologist) {    
+    function updateFeeSplit(uint256 _newFeeSplit) external mutualUpgrade(operator, methodologist) {
         require(
             _newFeeSplit <= PreciseUnitMath.preciseUnit(),
             "Operator Fee Split must be less than 1e18"

--- a/contracts/mocks/ChainlinkAggregatorV3Mock.sol
+++ b/contracts/mocks/ChainlinkAggregatorV3Mock.sol
@@ -1,8 +1,9 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 
 contract ChainlinkAggregatorV3Mock {
-    
+
     int256 private latestPrice;
 
     constructor() public {

--- a/contracts/mocks/FLIStrategyExtensionMock.sol
+++ b/contracts/mocks/FLIStrategyExtensionMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 pragma experimental ABIEncoderV2;
 
@@ -16,7 +17,7 @@ contract FLIStrategyExtensionMock {
     FlexibleLeverageStrategyExtension.ContractSettings internal strategy;
 
     mapping(string => FlexibleLeverageStrategyExtension.ExchangeSettings) internal exchangeSettings;
-    
+
 
     function shouldRebalanceWithBounds(
         uint256 /* _customMinLeverageRatio */,
@@ -31,7 +32,7 @@ contract FLIStrategyExtensionMock {
 
     function getChunkRebalanceNotional(
         string[] calldata /* _exchangeNames */
-    ) 
+    )
         external
         view
         returns(uint256[] memory sizes, address sellAsset, address buyAsset)

--- a/contracts/mocks/MasterChefMock.sol
+++ b/contracts/mocks/MasterChefMock.sol
@@ -1,7 +1,8 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 contract MasterChefMock {
-    
+
     uint256 private amount;
 
     constructor() public {

--- a/contracts/mocks/MasterChefMock.sol
+++ b/contracts/mocks/MasterChefMock.sol
@@ -9,7 +9,7 @@ contract MasterChefMock {
         amount = 0;
     }
 
-    function userInfo(uint256 _id, address _user) external view returns (uint256, uint256) {
+    function userInfo(uint256 _id, address /* _user */) external view returns (uint256, uint256) {
         if (_id == 75) return (amount, 0);
         return (0, 0);
     }

--- a/contracts/mocks/MutualUpgradeMock.sol
+++ b/contracts/mocks/MutualUpgradeMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 
 import { MutualUpgrade } from "../lib/MutualUpgrade.sol";

--- a/contracts/mocks/TradeAdapterMock.sol
+++ b/contracts/mocks/TradeAdapterMock.sol
@@ -25,7 +25,7 @@ contract TradeAdapterMock {
         address _destinationToken,
         address _destinationAddress,
         uint256 _sourceQuantity,
-        uint256 _minDestinationQuantity
+        uint256 /* _minDestinationQuantity */
     )
         external
     {

--- a/contracts/mocks/TradeAdapterMock.sol
+++ b/contracts/mocks/TradeAdapterMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity 0.6.10;
 pragma experimental ABIEncoderV2;
 

--- a/contracts/staking/RewardsDistributionRecipient.sol
+++ b/contracts/staking/RewardsDistributionRecipient.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity ^0.6.10;
 
 abstract contract RewardsDistributionRecipient {

--- a/contracts/staking/StakingRewards.sol
+++ b/contracts/staking/StakingRewards.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity ^0.6.10;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/staking/StakingRewardsV2.sol
+++ b/contracts/staking/StakingRewardsV2.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity ^0.6.10;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/token/IndexPowah.sol
+++ b/contracts/token/IndexPowah.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 
 pragma solidity 0.6.10;
@@ -30,7 +32,7 @@ import { Vesting } from "./Vesting.sol";
 /**
  * @title IndexPowah
  * @author Set Protocol
- * 
+ *
  * An ERC20 token used for tracking the voting power for the Index Coop. The mutative functions of
  * the ERC20 interface have been disabled since the token is only designed to count votes for the
  * sake of utilizing Snapshot's erc20-balance-of strategy. This contract is inspired by Sushiswap's
@@ -39,9 +41,9 @@ import { Vesting } from "./Vesting.sol";
 contract IndexPowah is IERC20, Ownable {
 
     using SafeMath for uint256;
-    
+
     IERC20 public indexToken;
-    
+
     IMasterChef public masterChef;
     uint256 public masterChefId;
     IPair public uniPair;
@@ -52,7 +54,7 @@ contract IndexPowah is IERC20, Ownable {
 
     /**
      * Sets the appropriate state variables for the contract.
-     * 
+     *
      * @param _owner        owner of this contract
      * @param _indexToken   Index Coop's governance token contract
      * @param _uniPair      INDEX-WETH Uniswap pair
@@ -124,7 +126,7 @@ contract IndexPowah is IERC20, Ownable {
 
     /**
      * ONLY OWNER: Updates the MasterChef contract and pool ID
-     * 
+     *
      * @param _newMasterChef    address of the new MasterChef contract
      * @param _newMasterChefId  new pool id for the index-eth MasterChef rewards
      */

--- a/contracts/token/IndexToken.sol
+++ b/contracts/token/IndexToken.sol
@@ -15,10 +15,10 @@ contract IndexToken {
     /// @notice Total number of tokens in circulation
     uint public constant totalSupply = 10000000e18; // 10 million INDEX
 
-    /// @notice Allowance amounts on behalf of others
+    /// @dev Allowance amounts on behalf of others
     mapping (address => mapping (address => uint96)) internal allowances;
 
-    /// @notice Official record of token balances for each account
+    /// @dev Official record of token balances for each account
     mapping (address => uint96) internal balances;
 
     /// @notice A record of each accounts delegate

--- a/contracts/token/IndexToken.sol
+++ b/contracts/token/IndexToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity ^0.6.10;
 pragma experimental ABIEncoderV2;
 

--- a/contracts/token/Vesting.sol
+++ b/contracts/token/Vesting.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
 pragma solidity ^0.6.10;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/viewers/FLIRebalanceViewer.sol
+++ b/contracts/viewers/FLIRebalanceViewer.sol
@@ -12,6 +12,8 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
 */
 pragma solidity 0.6.10;
 pragma experimental ABIEncoderV2;
@@ -116,7 +118,7 @@ contract FLIRebalanceViewer {
         ActionInfo memory actionInfo = _getActionInfo(_minLeverageRatio, _maxLeverageRatio);
 
         (uint256 uniswapV3Price, uint256 uniswapV2Price) = _getPrices(actionInfo);
-        
+
         return _getExchangePriority(
             uniswapV3Price,
             uniswapV2Price,
@@ -154,9 +156,9 @@ contract FLIRebalanceViewer {
      * @return uint256      price of trade on Uniswap V3
      */
     function _getV3Price(uint256 _sellSize, bool _isLever) internal returns (uint256) {
-        
-        bytes memory uniswapV3TradePath = _isLever ? 
-            fliStrategyExtension.getExchangeSettings(uniswapV3ExchangeName).leverExchangeData : 
+
+        bytes memory uniswapV3TradePath = _isLever ?
+            fliStrategyExtension.getExchangeSettings(uniswapV3ExchangeName).leverExchangeData :
             fliStrategyExtension.getExchangeSettings(uniswapV3ExchangeName).deleverExchangeData;
 
         uint256 outputAmount = uniswapV3Quoter.quoteExactInput(uniswapV3TradePath, _sellSize);
@@ -174,9 +176,9 @@ contract FLIRebalanceViewer {
      * @return uint256      price of trade on Uniswap V2
      */
     function _getV2Price(uint256 _sellSize, bool _isLever, address _sellAsset, address _buyAsset) internal view returns (uint256) {
-        
-        bytes memory uniswapV2TradePathRaw = _isLever ? 
-            fliStrategyExtension.getExchangeSettings(uniswapV2ExchangeName).leverExchangeData : 
+
+        bytes memory uniswapV2TradePathRaw = _isLever ?
+            fliStrategyExtension.getExchangeSettings(uniswapV2ExchangeName).leverExchangeData :
             fliStrategyExtension.getExchangeSettings(uniswapV2ExchangeName).deleverExchangeData;
 
         address[] memory uniswapV2TradePath;
@@ -187,9 +189,9 @@ contract FLIRebalanceViewer {
         } else {
             uniswapV2TradePath = abi.decode(uniswapV2TradePathRaw, (address[]));
         }
-        
+
         uint256 outputAmount = uniswapV2Router.getAmountsOut(_sellSize, uniswapV2TradePath)[uniswapV2TradePath.length.sub(1)];
-        
+
         // Divide to get ratio of quote / base asset. Don't care about decimals here. Standardizes to 10e18 with preciseDiv
         return outputAmount.preciseDiv(_sellSize);
     }


### PR DESCRIPTION
Small maintenance PR to make the solc compiler output more legible. Only changes comments, whitespace.

Removes dozens of warnings for SPDX (and handful of minor other things). There are still 4 license warnings coming from the Uniswap contracts we import from node_modules in the ExchangeIssuance contracts.

(Used Apache 2.0 for any files missing license info)

