### PR TITLE
feat: Contract to withdraw stranded tokens

### DIFF
--- a/contracts/utils/WithdrawTokens.sol
+++ b/contracts/utils/WithdrawTokens.sol
@@ -1,0 +1,34 @@
+/*
+    Copyright 2024 Index Cooperative
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title WithdrawTokens
+ * Contract to deploy to addresses where tokens (or eth) were accidentally sent
+ */
+contract WithdrawTokens is Ownable {
+    function withdraw(IERC20 token, uint256 amount) external onlyOwner {
+        if (address(token) == address(0)) {
+            payable(msg.sender).transfer(amount);
+        } else {
+            token.transfer(msg.sender, amount);
+        }
+    }
+}

--- a/test/integration/arbitrum/flashMintLeveragedExtended.spec.ts
+++ b/test/integration/arbitrum/flashMintLeveragedExtended.spec.ts
@@ -35,7 +35,7 @@ type SwapData = {
 };
 
 if (process.env.INTEGRATIONTEST) {
-  describe.only("FlashMintLeveragedExtended - Integration Test", async () => {
+  describe("FlashMintLeveragedExtended - Integration Test", async () => {
     const addresses = PRODUCTION_ADDRESSES;
     let owner: Account;
     let deployer: DeployHelper;

--- a/test/integration/arbitrum/withdrawTokens.spec.ts
+++ b/test/integration/arbitrum/withdrawTokens.spec.ts
@@ -1,0 +1,47 @@
+import { BigNumber, Signer, constants, utils } from "ethers";
+import { expect } from "chai";
+import { impersonateAccount, setBlockNumber } from "@utils/test/testingUtils";
+import { WithdrawTokens__factory } from "../../../typechain";
+
+if (process.env.INTEGRATIONTEST) {
+  describe.only("WithdrawTokens", function () {
+    const deployerAddress = "0x37e6365d4f6aE378467b0e24c9065Ce5f06D70bF";
+    let deployerSigner: Signer;
+
+    setBlockNumber(236525000);
+    before(async function () {
+      deployerSigner = await impersonateAccount(deployerAddress);
+    });
+
+    it("deploys to correct address", async function () {
+      const nonce = 1556;
+      const currentAccountNonce = await deployerSigner.getTransactionCount();
+
+      // Unfortunately we will have to spam a bunch of no-op transactions to get to the desired nonce
+      // Costs should be negligible though 21000 gas per tx. (at 0.01 gwei gas price on arbitrum -> 210 gwei)
+      for (let i = currentAccountNonce; i < nonce; i++) {
+        await deployerSigner.sendTransaction({
+          to: deployerAddress,
+          value: BigNumber.from(0),
+          nonce: i,
+        });
+      }
+      const expectedAddress = "0x940ecb16416fe52856e8653b2958bfd556aa6a7e";
+      const factory = await new WithdrawTokens__factory(deployerSigner);
+      const contract = await factory.deploy({ nonce });
+      await contract.deployed();
+      expect(contract.address.toLowerCase()).to.equal(expectedAddress);
+
+      const contractEthBalance = await deployerSigner.provider.getBalance(contract.address);
+      expect(contractEthBalance).to.gt(0);
+      console.log(`Contract eth balance: ${utils.formatEther(contractEthBalance)}`);
+
+      const deployerBalanceBefore = await deployerSigner.getBalance();
+      const tx = await contract.withdraw(constants.AddressZero, contractEthBalance);
+      const receipt = await tx.wait();
+      const deployerBalanceAfter = await deployerSigner.getBalance();
+      const txCost = tx.gasPrice.mul(receipt.gasUsed);
+      expect(deployerBalanceAfter).to.eq(deployerBalanceBefore.add(contractEthBalance).sub(txCost));
+    });
+  });
+}


### PR DESCRIPTION
In some cases eth has been sent to a mainnet contract address but on a different network (arbitrum) where that contract has not been deployed, resulting in the funds being stranded at that address.

This contract will be deployed to those addresses to recover users funds.