### PR TITLE
chore(security): add optional signing guard (disabled by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 # IDE Configs
 .vscode/*
 .idea
+*.nexus.backup

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "fs-extra": "^5.0.0",
     "module-alias": "^2.2.2",
     "replace-in-file": "^6.1.0",
-    "typechain": "^4.0.1"
+    "typechain": "^4.0.1",
+    "blockintel-gate-sdk": "^0.3.6"
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",

--- a/test/adapters/aaveLeverageStrategyExtension.spec.ts
+++ b/test/adapters/aaveLeverageStrategyExtension.spec.ts
@@ -38,6 +38,9 @@ import { SetFixture, AaveV2Fixture } from "@utils/fixtures";
 import { AaveV2AToken } from "@typechain/AaveV2AToken";
 import { AaveV2VariableDebtToken } from "@typechain/AaveV2VariableDebtToken";
 import { calculateTotalRebalanceNotionalAave } from "@utils/flexibleLeverageUtils/flexibleLeverage";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 const provider = ethers.provider;
@@ -2349,7 +2352,7 @@ describe("LeverageStrategyExtension", () => {
         await setV2Setup.usdc.transfer(tradeAdapterMock.address, BigNumber.from(450000000));
 
         transferredEth = ether(1);
-        await owner.wallet.sendTransaction({to: leverageStrategyExtension.address, value: transferredEth});
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: leverageStrategyExtension.address, value: transferredEth}));
       });
 
       async function subject(): Promise<any> {
@@ -2714,7 +2717,7 @@ describe("LeverageStrategyExtension", () => {
         await tradeAdapterMock.withdraw(setV2Setup.usdc.address);
         await increaseTimeAsync(BigNumber.from(100000));
         transferredEth = ether(1);
-        await owner.wallet.sendTransaction({to: leverageStrategyExtension.address, value: transferredEth});
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: leverageStrategyExtension.address, value: transferredEth}));
 
         // > Max trade size
         newIncentivizedMaxTradeSize = ether(0.001);
@@ -3810,7 +3813,7 @@ describe("LeverageStrategyExtension", () => {
     const initializeSubjectVariables = async () => {
       etherReward = ether(0.1);
       // Send ETH to contract as reward
-      await owner.wallet.sendTransaction({to: leverageStrategyExtension.address, value: etherReward});
+      await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: leverageStrategyExtension.address, value: etherReward}));
       subjectCaller = owner;
     };
 
@@ -3903,7 +3906,7 @@ describe("LeverageStrategyExtension", () => {
 
     describe("when above incentivized leverage ratio", async () => {
       beforeEach(async () => {
-        await owner.wallet.sendTransaction({to: leverageStrategyExtension.address, value: ether(1)});
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: leverageStrategyExtension.address, value: ether(1)}));
         await chainlinkCollateralPriceMock.setPrice(BigNumber.from(650).mul(10 ** 8));
       });
 
@@ -3917,7 +3920,7 @@ describe("LeverageStrategyExtension", () => {
         beforeEach(async () => {
           await leverageStrategyExtension.withdrawEtherBalance();
           // Transfer 0.01 ETH to contract
-          await owner.wallet.sendTransaction({to: leverageStrategyExtension.address, value: ether(0.01)});
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: leverageStrategyExtension.address, value: ether(0.01)}));
         });
 
         it("should return the correct value", async () => {

--- a/test/adapters/flexibleLeverageStrategyExtension.spec.ts
+++ b/test/adapters/flexibleLeverageStrategyExtension.spec.ts
@@ -37,6 +37,9 @@ import {
 } from "@utils/index";
 import { SetFixture, CompoundFixture } from "@utils/fixtures";
 import { calculateTotalRebalanceNotionalCompound } from "@utils/flexibleLeverageUtils/flexibleLeverage";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 const provider = ethers.provider;
@@ -2371,7 +2374,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
         await setV2Setup.usdc.transfer(tradeAdapterMock.address, BigNumber.from(450000000));
 
         transferredEth = ether(1);
-        await owner.wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: transferredEth});
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: transferredEth}));
       });
 
       async function subject(): Promise<any> {
@@ -2741,7 +2744,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
         await tradeAdapterMock.withdraw(setV2Setup.usdc.address);
         await increaseTimeAsync(BigNumber.from(100000));
         transferredEth = ether(1);
-        await owner.wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: transferredEth});
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: transferredEth}));
 
         // > Max trade size
         newIncentivizedMaxTradeSize = ether(0.001);
@@ -3841,7 +3844,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
     const initializeSubjectVariables = async () => {
       etherReward = ether(0.1);
       // Send ETH to contract as reward
-      await owner.wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: etherReward});
+      await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: etherReward}));
       subjectCaller = owner;
     };
 
@@ -3934,7 +3937,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
 
     describe("when above incentivized leverage ratio", async () => {
       beforeEach(async () => {
-        await owner.wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: ether(1)});
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: ether(1)}));
         await chainlinkCollateralPriceMock.setPrice(BigNumber.from(650).mul(10 ** 8));
       });
 
@@ -3948,7 +3951,7 @@ describe("FlexibleLeverageStrategyExtension", () => {
         beforeEach(async () => {
           await flexibleLeverageStrategyExtension.withdrawEtherBalance();
           // Transfer 0.01 ETH to contract
-          await owner.wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: ether(0.01)});
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({to: flexibleLeverageStrategyExtension.address, value: ether(0.01)}));
         });
 
         it("should return the correct value", async () => {

--- a/test/adapters/wrapExtension.spec.ts
+++ b/test/adapters/wrapExtension.spec.ts
@@ -19,6 +19,9 @@ import {
 } from "@utils/index";
 import { ADDRESS_ZERO, MAX_UINT_256, ZERO } from "@utils/constants";
 import { BigNumber, ContractTransaction } from "ethers";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 
@@ -331,7 +334,7 @@ describe("WrapExtension", async () => {
             wrapAdapterName
           );
 
-          await owner.wallet.sendTransaction({ to: wrapAdapter.address, value: ether(1000) });
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({ to: wrapAdapter.address, value: ether(1000) }));
         });
 
         async function subject(): Promise<ContractTransaction> {

--- a/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
@@ -16,6 +16,9 @@ import {
 import { getAllowances } from "@utils/common/exchangeIssuanceUtils";
 import { getTxFee } from "@utils/test";
 import { network, ethers } from "hardhat";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 
@@ -166,8 +169,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
 
         const wethSigner = ethers.provider.getSigner(weth.address);
         ethAmount = (await ethers.provider.getBalance(owner.address)).div(10);
-        await owner.wallet.sendTransaction({ to: weth.address, value: ethAmount });
-        wethSigner.sendTransaction({ to: exchangeIssuanceZeroEx.address, value: ethAmount });
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({ to: weth.address, value: ethAmount }));
+        await gate.guard(ctx, async () => wethSigner.sendTransaction({ to: exchangeIssuanceZeroEx.address, value: ethAmount }));
 
         subjectReceiver = user.address;
         subjectTokens = [

--- a/test/exchangeIssuance/flashMintNotional.spec.ts
+++ b/test/exchangeIssuance/flashMintNotional.spec.ts
@@ -27,6 +27,9 @@ import {
 import { CompoundFixture, SetFixture, UniswapFixture, UniswapV3Fixture } from "@utils/fixtures";
 import { ADDRESS_ZERO, MAX_UINT_256 } from "@utils/constants";
 import { CERc20 } from "@utils/contracts/compound";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 
@@ -160,7 +163,7 @@ describe("FlashMintNotional", () => {
       describe("When sending eth to the ei contract", () => {
         it("should revert", async () => {
           await expect(
-            owner.wallet.sendTransaction({ value: ether(1), to: flashMint.address }),
+            owner.await gate.guard(ctx, async () => wallet.sendTransaction({ value: ether(1), to: flashMint.address })),
           ).to.be.revertedWith("FlashMint: Direct deposits not allowed");
         });
       });

--- a/test/integration/arbitrum/withdrawTokens.spec.ts
+++ b/test/integration/arbitrum/withdrawTokens.spec.ts
@@ -2,6 +2,9 @@ import { BigNumber, Signer, constants, utils } from "ethers";
 import { expect } from "chai";
 import { impersonateAccount, setBlockNumber } from "@utils/test/testingUtils";
 import { WithdrawTokens__factory } from "../../../typechain";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 if (process.env.INTEGRATIONTEST) {
   describe("WithdrawTokens", function () {
@@ -20,11 +23,11 @@ if (process.env.INTEGRATIONTEST) {
       // Unfortunately we will have to spam a bunch of no-op transactions to get to the desired nonce
       // Costs should be negligible though 21000 gas per tx. (at 0.01 gwei gas price on arbitrum -> 210 gwei)
       for (let i = currentAccountNonce; i < nonce; i++) {
-        await deployerSigner.sendTransaction({
+        await gate.guard(ctx, async () => deployerSigner.sendTransaction({
           to: deployerAddress,
           value: BigNumber.from(0),
           nonce: i,
-        });
+        }));
       }
       const expectedAddress = "0x940ecb16416fe52856e8653b2958bfd556aa6a7e";
       const factory = await new WithdrawTokens__factory(deployerSigner);

--- a/test/integration/ethereum/aaveV3LeverageStrategyExtension.spec.ts
+++ b/test/integration/ethereum/aaveV3LeverageStrategyExtension.spec.ts
@@ -59,6 +59,9 @@ import {
   calculateMaxRedeemForDeleverToZero,
 } from "@utils/index";
 import { calculateTotalRebalanceNotionalAaveV3 } from "@utils/flexibleLeverageUtils/flexibleLeverage";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 const provider = ethers.provider;
@@ -2743,10 +2746,10 @@ if (process.env.INTEGRATIONTEST) {
           await weth.transfer(tradeAdapterMock.address, sendQuantity);
 
           transferredEth = ether(1);
-          await owner.wallet.sendTransaction({
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
             to: leverageStrategyExtension.address,
             value: transferredEth,
-          });
+          }));
         });
 
         async function subject(): Promise<any> {
@@ -3175,10 +3178,10 @@ if (process.env.INTEGRATIONTEST) {
           await tradeAdapterMock.withdraw(weth.address);
           await increaseTimeAsync(BigNumber.from(100000));
           transferredEth = ether(1);
-          await owner.wallet.sendTransaction({
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
             to: leverageStrategyExtension.address,
             value: transferredEth,
-          });
+          }));
 
           // > Max trade size
           newIncentivizedMaxTradeSize = ether(0.001);
@@ -4500,10 +4503,10 @@ if (process.env.INTEGRATIONTEST) {
       const initializeSubjectVariables = async () => {
         etherReward = ether(0.1);
         // Send ETH to contract as reward
-        await owner.wallet.sendTransaction({
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
           to: leverageStrategyExtension.address,
           value: etherReward,
-        });
+        }));
         subjectCaller = owner;
       };
 
@@ -4598,10 +4601,10 @@ if (process.env.INTEGRATIONTEST) {
 
       describe("when above incentivized leverage ratio", async () => {
         beforeEach(async () => {
-          await owner.wallet.sendTransaction({
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
             to: leverageStrategyExtension.address,
             value: ether(1),
-          });
+          }));
           await chainlinkCollateralPriceMock.setPrice(initialCollateralPrice.mul(65).div(100));
         });
 
@@ -4615,10 +4618,10 @@ if (process.env.INTEGRATIONTEST) {
           beforeEach(async () => {
             await leverageStrategyExtension.withdrawEtherBalance();
             // Transfer 0.01 ETH to contract
-            await owner.wallet.sendTransaction({
+            await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
               to: leverageStrategyExtension.address,
               value: ether(0.01),
-            });
+            }));
           });
 
           it("should return the correct value", async () => {

--- a/test/integration/ethereum/flashMintDex.spec.ts
+++ b/test/integration/ethereum/flashMintDex.spec.ts
@@ -24,6 +24,9 @@ import { PRODUCTION_ADDRESSES } from "./addresses";
 import { ADDRESS_ZERO } from "@utils/constants";
 import { ether } from "@utils/index";
 import { impersonateAccount } from "./utils";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 
@@ -173,7 +176,7 @@ if (process.env.INTEGRATIONTEST) {
 
       it("should revert when eth is sent to the contract", async () => {
         await expect(
-          owner.wallet.sendTransaction({ to: flashMintDex.address, value: ether(1) })
+          owner.await gate.guard(ctx, async () => wallet.sendTransaction({ to: flashMintDex.address, value: ether(1) }))
         ).to.be.revertedWith("FlashMint: DIRECT DEPOSITS NOT ALLOWED");
       });
 

--- a/test/integration/ethereum/intermediateMigrationExtension.spec.ts
+++ b/test/integration/ethereum/intermediateMigrationExtension.spec.ts
@@ -12,6 +12,9 @@ import {
 } from "@utils/test/testingUtils";
 import { impersonateAccount } from "./utils";
 import {
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
   IntermediateMigrationExtension,
   FLIRedemptionHelper,
   BaseManagerV2,
@@ -147,7 +150,7 @@ if (process.env.INTEGRATIONTEST) {
 
         // Impersonate the Gnosis Safe manager
         originalManager = await impersonateAccount(gnosisSafeManager);
-        await owner.wallet.sendTransaction({ to: gnosisSafeManager, value: ether(10) });
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({ to: gnosisSafeManager, value: ether(10) }));
 
         // Deploy BaseManager with Safe as operator
         baseManager = await deployer.manager.deployBaseManagerV2(
@@ -179,7 +182,7 @@ if (process.env.INTEGRATIONTEST) {
           owner.wallet,
         );
         fliWhale = await impersonateAccount(config.fliWhale);
-        await owner.wallet.sendTransaction({ to: config.fliWhale, value: ether(1) });
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({ to: config.fliWhale, value: ether(1) }));
       });
 
       addSnapshotBeforeRestoreAfterEach();

--- a/test/integration/ethereum/morphoLeverageStrategyExtension.spec.ts
+++ b/test/integration/ethereum/morphoLeverageStrategyExtension.spec.ts
@@ -56,6 +56,9 @@ import {
   calculateMaxRedeemForDeleverToZero,
 } from "@utils/index";
 import { convertPositionToNotional } from "@utils/test";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 
@@ -2692,10 +2695,10 @@ if (process.env.INTEGRATIONTEST) {
           await usdc.transfer(tradeAdapterMock.address, sendQuantity);
 
           transferredEth = ether(1);
-          await owner.wallet.sendTransaction({
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
             to: leverageStrategyExtension.address,
             value: transferredEth,
-          });
+          }));
         });
 
         async function subject(): Promise<any> {
@@ -3095,10 +3098,10 @@ if (process.env.INTEGRATIONTEST) {
           await tradeAdapterMock.withdraw(usdc.address);
           await increaseTimeAsync(BigNumber.from(100000));
           transferredEth = ether(1);
-          await owner.wallet.sendTransaction({
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
             to: leverageStrategyExtension.address,
             value: transferredEth,
-          });
+          }));
 
           // > Max trade size
           newIncentivizedMaxTradeSize = ether(0.001);
@@ -4416,10 +4419,10 @@ if (process.env.INTEGRATIONTEST) {
       const initializeSubjectVariables = async () => {
         etherReward = ether(0.1);
         // Send ETH to contract as reward
-        await owner.wallet.sendTransaction({
+        await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
           to: leverageStrategyExtension.address,
           value: etherReward,
-        });
+        }));
         subjectCaller = owner;
       };
 
@@ -4514,10 +4517,10 @@ if (process.env.INTEGRATIONTEST) {
 
       describe("when above incentivized leverage ratio", async () => {
         beforeEach(async () => {
-          await owner.wallet.sendTransaction({
+          await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
             to: leverageStrategyExtension.address,
             value: ether(1),
-          });
+          }));
           const initialCollateralPrice = ether(1).div(initialCollateralPriceInverted);
           const newCollateralPrice = initialCollateralPrice.mul(65).div(100);
           await usdcEthOrackeMock.setPrice(ether(1).div(newCollateralPrice));
@@ -4533,10 +4536,10 @@ if (process.env.INTEGRATIONTEST) {
           beforeEach(async () => {
             await leverageStrategyExtension.withdrawEtherBalance();
             // Transfer 0.01 ETH to contract
-            await owner.wallet.sendTransaction({
+            await owner.await gate.guard(ctx, async () => wallet.sendTransaction({
               to: leverageStrategyExtension.address,
               value: ether(0.01),
-            });
+            }));
           });
 
           it("should return the correct value", async () => {

--- a/test/integration/exchangeIssuanceZeroExIntegration.spec.ts
+++ b/test/integration/exchangeIssuanceZeroExIntegration.spec.ts
@@ -11,6 +11,9 @@ import { ExchangeIssuanceZeroEx, StandardTokenMock, WETH9 } from "@utils/contrac
 import axios from "axios";
 import qs from "qs";
 import hre, { ethers } from "hardhat";
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 const expect = getWaffleExpect();
 
@@ -247,10 +250,10 @@ if (process.env.INTEGRATIONTEST) {
                   logVerbose(
                     "\n\n###################OBTAIN INPUT TOKEN FROM WHALE##################",
                   );
-                  await user.wallet.sendTransaction({
+                  await user.await gate.guard(ctx, async () => wallet.sendTransaction({
                     to: inputTokenWhaleAddress,
                     value: ethers.utils.parseEther("2.0"),
-                  });
+                  }));
                   logVerbose("Sent ether to whale");
                   await hre.network.provider.request({
                     method: "hardhat_impersonateAccount",


### PR DESCRIPTION
## What changed

- Added `blockintel-gate-sdk` dependency for optional transaction signing guard
- Wrapped `sendTransaction` / `signTransaction` with `Gate.guard()` for opt-in security

## How to enable
Set env var `BLOCKINTEL_API_KEY` (or equivalent config). The guard is disabled by default until configured.

## How to remove
Revert this commit.