### PR TITLE
fix(FlashMintDexV5): sync external position modules before issue & redeem

### DIFF
--- a/contracts/exchangeIssuance/FlashMintDexV5.sol
+++ b/contracts/exchangeIssuance/FlashMintDexV5.sol
@@ -450,6 +450,13 @@ contract FlashMintDexV5 is Ownable, ReentrancyGuard {
     */
     function _issueExactSetFromWeth(IssueRedeemParams memory _issueParams) internal returns (uint256 totalWethSpent)
     {
+        // Refresh any external-position units (e.g. Morpho/Aave leverage modules)
+        // before reading the SetToken's required components. Without this, the
+        // V3 issuance module's external view returns the SetToken's stored unit
+        // — which can lag the live protocol state — while the actual issue()
+        // pull syncs first and reads a fresher value, and the contract runs
+        // short. See _syncExternalPositions for the full rationale.
+        _syncExternalPositions(_issueParams.setToken);
         totalWethSpent = _buyComponentsWithWeth(_issueParams);
         IBasicIssuanceModule(_issueParams.issuanceModule).issue(_issueParams.setToken, _issueParams.amountSetToken, msg.sender);
     }
@@ -536,13 +543,54 @@ contract FlashMintDexV5 is Ownable, ReentrancyGuard {
     }
 
     /**
+     * @dev Best-effort `sync(setToken)` against every external position module
+     * attached to any of the SetToken's components.
+     *
+     * Why: DebtIssuanceModuleV3.getRequiredComponentIssuanceUnits returns a
+     * balance-derived per-share equity unit, which for components held as
+     * external positions (e.g. Morpho/Aave leverage modules) reads the
+     * SetToken's *stored* external-position unit. That stored value only
+     * advances when the leverage module's _sync writes to it. The V3 internal
+     * issue()/redeem() flow runs the module's pre-hook (which calls sync)
+     * before reading the unit, so the pull sees a freshly-synced value.
+     * Without an upfront sync from this contract, the FlashMint's read sees
+     * a stale unit and the actual pull demands more — `ERC20InsufficientBalance`.
+     *
+     * We iterate the SetToken's components × external position modules and
+     * low-level-call `sync(address)` on each. Modules that don't implement the
+     * function (or revert for any reason) are silently skipped — this is a
+     * best-effort refresh, not a precondition.
+     */
+    function _syncExternalPositions(ISetToken _setToken) internal {
+        address[] memory components = _setToken.getComponents();
+        for (uint256 i = 0; i < components.length; i++) {
+            address[] memory modules = _setToken.getExternalPositionModules(components[i]);
+            for (uint256 j = 0; j < modules.length; j++) {
+                // Best-effort: ignore success/return data. ABI for sync(address)
+                // matches MorphoLeverageModule, AaveLeverageModule, etc. Modules
+                // without it just no-op via the EVM's empty-fallback / return-true.
+                // solhint-disable-next-line avoid-low-level-calls
+                (bool success, ) = modules[j].call(abi.encodeWithSignature("sync(address)", address(_setToken)));
+                success;
+            }
+        }
+    }
+
+    /**
      * Transfers given amount of set token from the sender and redeems it for underlying components.
      * Obtained component tokens are sent to this contract.
+     *
+     * Mirror the issuance side: refresh external-position units before redeem so the V3
+     * redemption view (used downstream by _sellComponentsForWeth) returns the same per-share
+     * unit the SetToken's redeem() will actually transfer to this contract. Without it,
+     * _sellComponentsForWeth would sell the stale-view amount and leave any drift portion
+     * as dust on this contract instead of forwarding it as additional output to the user.
      *
      * @param _setToken     Address of the SetToken to be redeemed
      * @param _amount       Amount of SetToken to be redeemed
      */
     function _redeem(ISetToken _setToken, uint256 _amount, address _issuanceModule) internal returns (uint256) {
+        _syncExternalPositions(_setToken);
         _setToken.safeTransferFrom(msg.sender, address(this), _amount);
         IBasicIssuanceModule(_issuanceModule).redeem(_setToken, _amount, address(this));
     }

--- a/test/integration/base/flashMintDexV5.spec.ts
+++ b/test/integration/base/flashMintDexV5.spec.ts
@@ -65,9 +65,14 @@ const aerodromeSlipstreamQuoterAddress = "0x254cF9E1E6e233aa1AC962CB9B05b2cfeAaE
 // Delevered Morpho leverage tokens (post-disengage on Base)
 const uSOL = "0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55";
 const uSUI = "0xb0505e5a99abd03d94a1169e638B78EDfEd26ea4";
+const uXRP = "0x2615a94df961278DcbC41Fb0a54fEc5f10a693aE";
 const uSOL2x = "0x0A0Fbd86d2dEB53D7C65fecF8622c2Fa0DCdc9c6";
 const uSUI2x = "0x2F67e4bE7fBF53dB88881324AAc99e9D85208d40";
 const uSOL3x = "0x16c469F88979e19A53ea522f0c77aFAD9A043571";
+const uXRP2x = "0x32BB8FF692A2F14C05Fe7a5ae78271741bD392fC";
+// uXRP2x's largest holder — used as a SetToken whale for redemption tests, but
+// here we only need to verify that the issue path no longer reverts.
+// (Whale doesn't matter for the new spec; we issue from scratch via WETH.)
 
 // WETH whale on Base — Aerodrome SlipStream uSOL/WETH pool, ~50 WETH
 const wethWhale = "0x0225Ba893D5f8Ecd6d2022f9dEC59b34F61098A1";
@@ -388,6 +393,77 @@ if (process.env.INTEGRATIONTEST) {
         await flashMintDexV5.issueExactSetFromERC20(
           {
             setToken: uSOL2x,
+            amountSetToken: setAmount,
+            componentSwapData,
+            issuanceModule: debtIssuanceModuleAddress,
+            isDebtIssuance: true,
+          },
+          {
+            token: wethAddress,
+            limitAmt: maxWeth,
+            swapDataTokenToWeth: noopSwap,
+            swapDataWethToToken: noopSwap,
+          },
+          0,
+        );
+        const setAfter = await setToken.balanceOf(owner.address);
+        expect(setAfter.sub(setBefore)).to.eq(setAmount);
+      });
+    });
+
+    // Regression for the larger Morpho-position drift on uXRP2x. The stored
+    // external-position unit on uXRP2x lags actual Morpho collateral by
+    // ~7500 wei per set (vs ≤1 wei/set for uSOL/uSUI products), so the
+    // position-vs-balance buffer alone (`setAmount/1e18 + 1`) cannot cover the
+    // gap at any non-trivial setAmount. The fix is _syncExternalPositions: an
+    // upfront sync of every attached external-position module rewrites the
+    // SetToken's stored unit to match live Morpho state, after which the V3
+    // external view and the internal pull agree exactly.
+    describe("regression: uXRP2x issuance refreshed via _syncExternalPositions", () => {
+      // Whale has ~0.011 uXRP2x; pick a setAmount well under that since fundWeth
+      // does not strictly cap us, but staying conservative here matches the SDK
+      // e2e test scenarios and would cleanly revert with the un-patched
+      // contract (deficit of ~7500 wei × any setAmount > 0 ≫ buffer of 1
+      // wei/set).
+      const setAmount = ether(0.005);
+      let setToken: IERC20;
+
+      const componentSwapData: SwapData[] = [
+        {
+          path: [wethAddress, uXRP],
+          fees: [],
+          tickSpacing: [slipstreamTickSpacing],
+          pool: ADDRESS_ZERO,
+          poolIds: [],
+          exchange: Exchange.AerodromeSlipstream,
+        },
+      ];
+
+      before(async () => {
+        setToken = (await ethers.getContractAt("IERC20", uXRP2x)) as IERC20;
+        await flashMintDexV5.approveSetToken(uXRP2x, debtIssuanceModuleAddress);
+      });
+
+      it("issues uXRP2x from WETH after sync (would revert pre-fix)", async () => {
+        const wethEstimate = await flashMintDexV5.callStatic.getIssueExactSet(
+          {
+            setToken: uXRP2x,
+            amountSetToken: setAmount,
+            componentSwapData,
+            issuanceModule: debtIssuanceModuleAddress,
+            isDebtIssuance: true,
+          },
+          noopSwap,
+        );
+        const maxWeth = wethEstimate.mul(110).div(100);
+
+        await fundWeth(owner.address, maxWeth);
+        await weth.approve(flashMintDexV5.address, maxWeth);
+
+        const setBefore = await setToken.balanceOf(owner.address);
+        await flashMintDexV5.issueExactSetFromERC20(
+          {
+            setToken: uXRP2x,
             amountSetToken: setAmount,
             componentSwapData,
             issuanceModule: debtIssuanceModuleAddress,


### PR DESCRIPTION


DebtIssuanceModuleV3.getRequiredComponentIssuanceUnits returns the SetToken's *stored* per-share equity unit for components held as external positions (e.g. Morpho leverage module). That stored unit only advances when the module's _sync writes to it. The V3 internal issue() flow runs the module's pre-hook (which calls sync) before reading the unit, so the pull sees a fresher value than the view returned. For products whose external position has drifted from live protocol state — uXRP2x in our delevered set, where the gap is ~7530 wei per set — the FlashMint runs short and reverts with ERC20InsufficientBalance.

Add `_syncExternalPositions(setToken)` that iterates the SetToken's components × external position modules and best-effort low-level-calls sync(address) on each. Call it at the top of _issueExactSetFromWeth and _redeem so the contract sees the same per-share unit the issuance module's internal flow will. This mirrors the existing pattern used by FlashMintLeveragedMorphoV2 / FlashMintLeveragedMorphoAaveLM, but generalised: those take their leverage module via constructor; this inspects the SetToken at runtime and works for any external position module that exposes sync(address).

Add a regression spec that issues uXRP2x at setAmount=0.005 ether — would revert with the patched-but-buffer-only 0.45.1 contract (deficit of ~7530 wei × 0.005 sets ≫ buffer of 1 wei/set), passes here.